### PR TITLE
idを自動採番(autoincrement)化

### DIFF
--- a/project/prisma/migrations/20260705145749_item_id_autoincrement/migration.sql
+++ b/project/prisma/migrations/20260705145749_item_id_autoincrement/migration.sql
@@ -1,0 +1,8 @@
+-- Make item.id auto-increment (SERIAL-style) and the table's primary key.
+CREATE SEQUENCE IF NOT EXISTS "item_id_seq";
+ALTER TABLE "item" ALTER COLUMN "id" SET DEFAULT nextval('item_id_seq');
+ALTER SEQUENCE "item_id_seq" OWNED BY "item"."id";
+SELECT setval('item_id_seq', COALESCE((SELECT MAX(id) FROM "item"), 0) + 1, false);
+
+DROP INDEX IF EXISTS "item_id_key";
+ALTER TABLE "item" ADD CONSTRAINT "item_pkey" PRIMARY KEY ("id");

--- a/project/prisma/schema.prisma
+++ b/project/prisma/schema.prisma
@@ -15,8 +15,8 @@ datasource db {
 }   
 
 model item {
-  id Int @unique
-  date DateTime
-  name String
+  id    Int      @id @default(autoincrement())
+  date  DateTime
+  name  String
   price Int
 }

--- a/project/src/app/api/insert/route.ts
+++ b/project/src/app/api/insert/route.ts
@@ -33,7 +33,6 @@ export async function POST(request: Request) {
   const sql = neon(connectionString);
 
   // 各値を適切な型に変換
-  const id = Number.parseInt(data.id);
   const price = Number.parseInt(data.price);
   const name = data.name;
   const date = data.date
@@ -41,19 +40,12 @@ export async function POST(request: Request) {
     : new Date().toISOString();
 
   try {
-    // idの重複チェック
-    const existing = await sql`SELECT id FROM item WHERE id = ${id}`;
-    if (existing.length > 0) {
-      return NextResponse.json({
-        success: false,
-        error: "同じIDが既に存在します(よくない)",
-      });
-    }
-    await sql`
-      INSERT INTO item (id, date, name, price)
-      VALUES (${id}, ${date}, ${name}, ${price})
+    const result = await sql`
+      INSERT INTO item (date, name, price)
+      VALUES (${date}, ${name}, ${price})
+      RETURNING id
     `;
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, id: result[0].id });
   } catch (e: any) {
     return NextResponse.json({ success: false, error: e?.toString() });
   }
@@ -64,7 +56,6 @@ export async function POST(request: Request) {
  */
 function validateData(data: any) {
   if (!data) return "データがありません";
-  if (!data.id || isNaN(Number(data.id))) return "idが不正です";
   if (!data.name || typeof data.name !== "string") return "nameが不正です";
   if (!data.price || isNaN(Number(data.price))) return "priceが不正です";
   return null;

--- a/project/src/app/entry/page.tsx
+++ b/project/src/app/entry/page.tsx
@@ -11,7 +11,7 @@ import React, { useState } from "react";
 
 export default function Confirm() {
   // state
-  const [form, setForm] = useState({ id: "", date: "", name: "", price: "" });
+  const [form, setForm] = useState({ date: "", name: "", price: "" });
   const [message, setMessage] = useState("");
 
   // 入力欄が変更されたときに呼ばれる関数
@@ -42,23 +42,13 @@ export default function Confirm() {
     );
     // 送信成功時はフォームをクリア
     if (data.success) {
-      setForm({ id: "", date: "", name: "", price: "" });
+      setForm({ date: "", name: "", price: "" });
     }
   };
 
   return (
     // フォーム：onSubmitでhandleSubmitが呼び出し
     <form onSubmit={handleSubmit} className={styles.form}>
-      <label className={styles.label} htmlFor="id">
-        ID
-        <input
-          id="id"
-          name="id"
-          value={form.id}
-          onChange={handleChange}
-          className={styles.input}
-        />
-      </label>
       <label className={styles.label} htmlFor="date">
         日付
         <input


### PR DESCRIPTION
## Summary
- item.idをautoincrementに変更し、手入力・重複チェックを廃止
- 既存テーブル向けマイグレーションを追加(未適用。適用要否は別途確認)
- /api/insertはidを受け取らずRETURNING idで採番結果を返す
- entryフォームからID入力欄を削除

Closes #15

## Test plan
- [ ] マイグレーションをNeon DBに適用 (`prisma migrate deploy`)
- [ ] /entry からデータ登録し、idが自動採番されることを確認
- [ ] /list で登録したデータが表示されることを確認
- [ ] 環境のNode.js/npmが使えないため、ローカルでのbuild/lint未実施。適用前に確認要