### PR TITLE
編集・削除機能の追加

### DIFF
--- a/project/src/app/api/delete/route.ts
+++ b/project/src/app/api/delete/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { neon } from "@neondatabase/serverless";
+
+export const runtime = "edge";
+
+/**
+ * itemテーブルのレコードを削除するAPIエンドポイント
+ */
+export async function DELETE(request: Request) {
+  let data;
+  try {
+    data = await request.json();
+  } catch (e) {
+    return NextResponse.json({
+      success: false,
+      error: "JSONのパースに失敗しました",
+    });
+  }
+
+  if (!data?.id || isNaN(Number(data.id))) {
+    return NextResponse.json({ success: false, error: "idが不正です" });
+  }
+
+  // DB接続文字列を取得
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    return NextResponse.json({
+      success: false,
+      error: "DATABASE_URLが設定されていません",
+    });
+  }
+  const sql = neon(connectionString);
+  const id = Number.parseInt(data.id);
+
+  try {
+    const result = await sql`
+      DELETE FROM item WHERE id = ${id} RETURNING id
+    `;
+    if (result.length === 0) {
+      return NextResponse.json({
+        success: false,
+        error: "対象のデータが見つかりません",
+      });
+    }
+    return NextResponse.json({ success: true });
+  } catch (e: any) {
+    return NextResponse.json({ success: false, error: e?.toString() });
+  }
+}

--- a/project/src/app/api/update/route.ts
+++ b/project/src/app/api/update/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { neon } from "@neondatabase/serverless";
+
+export const runtime = "edge";
+
+/**
+ * itemテーブルの既存レコードを更新するAPIエンドポイント
+ */
+export async function PUT(request: Request) {
+  let data;
+  try {
+    data = await request.json();
+  } catch (e) {
+    return NextResponse.json({
+      success: false,
+      error: "JSONのパースに失敗しました",
+    });
+  }
+
+  const validationError = validateData(data);
+  if (validationError) {
+    return NextResponse.json({ success: false, error: validationError });
+  }
+
+  // DB接続文字列を取得
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    return NextResponse.json({
+      success: false,
+      error: "DATABASE_URLが設定されていません",
+    });
+  }
+  const sql = neon(connectionString);
+
+  // 各値を適切な型に変換
+  const id = Number.parseInt(data.id);
+  const price = Number.parseInt(data.price);
+  const name = data.name;
+  const date = new Date(data.date).toISOString();
+
+  try {
+    const result = await sql`
+      UPDATE item
+      SET date = ${date}, name = ${name}, price = ${price}
+      WHERE id = ${id}
+      RETURNING id
+    `;
+    if (result.length === 0) {
+      return NextResponse.json({
+        success: false,
+        error: "対象のデータが見つかりません",
+      });
+    }
+    return NextResponse.json({ success: true });
+  } catch (e: any) {
+    return NextResponse.json({ success: false, error: e?.toString() });
+  }
+}
+
+/**
+ * データのバリデーションを行う関数
+ */
+function validateData(data: any) {
+  if (!data) return "データがありません";
+  if (!data.id || isNaN(Number(data.id))) return "idが不正です";
+  if (!data.name || typeof data.name !== "string") return "nameが不正です";
+  if (!data.price || isNaN(Number(data.price))) return "priceが不正です";
+  return null;
+}

--- a/project/src/app/list/page.tsx
+++ b/project/src/app/list/page.tsx
@@ -7,8 +7,11 @@ const styles = {
   table: "w-full border",
   th: "border px-2 py-1",
   td: "border px-2 py-1",
+  editableTd: "border px-2 py-1 cursor-pointer",
+  input: "w-full border px-1",
   error: "text-center text-red-500",
   loading: "text-center",
+  button: "px-2 py-1 text-sm",
 };
 
 // Reactフック
@@ -29,6 +32,13 @@ export default function EntryList() {
   const [items, setItems] = useState<Item[]>([]); //データの配列
   const [loading, setLoading] = useState(true); //ローディングかどうか
   const [error, setError] = useState(""); //エラーメッセージ
+
+  // 編集中の行id(nullなら編集していない)
+  const [editingId, setEditingId] = useState<number | null>(null);
+  // 編集中の入力値
+  const [editForm, setEditForm] = useState({ date: "", name: "", price: "" });
+  // 保存・削除時のエラーメッセージ
+  const [actionError, setActionError] = useState("");
 
   useEffect(() => {
     // 関数の実行タイミングをReactのレンダリング後まで遅らせる
@@ -55,10 +65,77 @@ export default function EntryList() {
     fetchData(); // データ取得実行
   }, []);
 
+  // 行クリックで編集モードに入る
+  const startEdit = (item: Item) => {
+    setActionError("");
+    setEditingId(item.id);
+    setEditForm({
+      date: item.date.slice(0, 10),
+      name: item.name,
+      price: String(item.price),
+    });
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setActionError("");
+  };
+
+  const handleEditChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEditForm({ ...editForm, [e.target.name]: e.target.value });
+  };
+
+  // 編集内容を保存
+  const saveEdit = async (id: number) => {
+    setActionError("");
+    const res = await fetch("/api/update", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id, ...editForm }),
+    });
+    const data = await res.json();
+    if (data.success) {
+      setItems((prev) =>
+        prev.map((item) =>
+          item.id === id
+            ? {
+                ...item,
+                date: new Date(editForm.date).toISOString(),
+                name: editForm.name,
+                price: Number.parseInt(editForm.price),
+              }
+            : item
+        )
+      );
+      setEditingId(null);
+    } else {
+      setActionError(data.error || "更新に失敗しました");
+    }
+  };
+
+  // 削除
+  const deleteItem = async (id: number) => {
+    if (!window.confirm("削除しますか？")) return;
+    setActionError("");
+    const res = await fetch("/api/delete", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id }),
+    });
+    const data = await res.json();
+    if (data.success) {
+      setItems((prev) => prev.filter((item) => item.id !== id));
+      if (editingId === id) setEditingId(null);
+    } else {
+      setActionError(data.error || "削除に失敗しました");
+    }
+  };
+
   // 画面描画
   return (
     <div className={styles.container}>
       <h1 className={styles.title}>一覧画面</h1>
+      {actionError && <div className={styles.error}>{actionError}</div>}
       {loading ? (
         <div className={styles.loading}>動いてます</div>
       ) : error ? (
@@ -71,17 +148,79 @@ export default function EntryList() {
               <th className={styles.th}>日付</th>
               <th className={styles.th}>名前</th>
               <th className={styles.th}>金額</th>
+              <th className={styles.th}>操作</th>
             </tr>
           </thead>
           <tbody>
-            {items.map((item) => (
-              <tr key={item.id}>
-                <td className={styles.td}>{item.id}</td>
-                <td className={styles.td}>{item.date?.slice(0, 10)}</td>
-                <td className={styles.td}>{item.name}</td>
-                <td className={styles.td}>{item.price}</td>
-              </tr>
-            ))}
+            {items.map((item) =>
+              editingId === item.id ? (
+                <tr key={item.id}>
+                  <td className={styles.td}>{item.id}</td>
+                  <td className={styles.td}>
+                    <input
+                      type="date"
+                      name="date"
+                      value={editForm.date}
+                      onChange={handleEditChange}
+                      className={styles.input}
+                    />
+                  </td>
+                  <td className={styles.td}>
+                    <input
+                      name="name"
+                      value={editForm.name}
+                      onChange={handleEditChange}
+                      className={styles.input}
+                    />
+                  </td>
+                  <td className={styles.td}>
+                    <input
+                      name="price"
+                      value={editForm.price}
+                      onChange={handleEditChange}
+                      className={styles.input}
+                    />
+                  </td>
+                  <td className={styles.td}>
+                    <button
+                      className={styles.button}
+                      onClick={() => saveEdit(item.id)}
+                    >
+                      保存
+                    </button>
+                    <button className={styles.button} onClick={cancelEdit}>
+                      キャンセル
+                    </button>
+                    <button
+                      className={styles.button}
+                      onClick={() => deleteItem(item.id)}
+                    >
+                      削除
+                    </button>
+                  </td>
+                </tr>
+              ) : (
+                <tr key={item.id} onClick={() => startEdit(item)}>
+                  <td className={styles.editableTd}>{item.id}</td>
+                  <td className={styles.editableTd}>
+                    {item.date?.slice(0, 10)}
+                  </td>
+                  <td className={styles.editableTd}>{item.name}</td>
+                  <td className={styles.editableTd}>{item.price}</td>
+                  <td className={styles.td}>
+                    <button
+                      className={styles.button}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        deleteItem(item.id);
+                      }}
+                    >
+                      削除
+                    </button>
+                  </td>
+                </tr>
+              )
+            )}
           </tbody>
         </table>
       )}


### PR DESCRIPTION
## Summary
- /api/update (PUT) でitemの更新、/api/delete (DELETE) で削除を実装
- /list画面で行をクリックするとインライン編集モードになり、その場で保存・キャンセル・削除できるUIを追加

Closes #16

## Test plan
- [x] ローカルPostgres + Prisma Clientで、update/delete相当のSQL(WHERE id指定のUPDATE/DELETE RETURNING id)が期待通り動作することを確認
- [ ] 実際の/api/update・/api/delete(neon()経由)は本番Neon DBへの接続が必要なため未検証。マージ前に本番相当環境での動作確認を推奨
- [ ] /listで行クリック→編集→保存、行の削除ボタンの実ブラウザ確認