### PR TITLE
カテゴリ・収支種別の項目追加

### DIFF
--- a/project/prisma/migrations/20260705155430_add_category_and_type/migration.sql
+++ b/project/prisma/migrations/20260705155430_add_category_and_type/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "item" ADD COLUMN     "category" TEXT NOT NULL DEFAULT 'その他',
+ADD COLUMN     "type" TEXT NOT NULL DEFAULT '支出';

--- a/project/prisma/schema.prisma
+++ b/project/prisma/schema.prisma
@@ -15,8 +15,10 @@ datasource db {
 }   
 
 model item {
-  id    Int      @id @default(autoincrement())
-  date  DateTime
-  name  String
-  price Int
+  id       Int      @id @default(autoincrement())
+  date     DateTime
+  name     String
+  price    Int
+  category String   @default("その他")
+  type     String   @default("支出")
 }

--- a/project/src/app/api/insert/route.ts
+++ b/project/src/app/api/insert/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { neon } from "@neondatabase/serverless";
+import { CATEGORIES_BY_TYPE, ITEM_TYPES, ItemType } from "@/lib/categories";
 
 export const runtime = "edge";
 
@@ -38,11 +39,13 @@ export async function POST(request: Request) {
   const date = data.date
     ? new Date(data.date).toISOString()
     : new Date().toISOString();
+  const type = data.type as ItemType;
+  const category = data.category;
 
   try {
     const result = await sql`
-      INSERT INTO item (date, name, price)
-      VALUES (${date}, ${name}, ${price})
+      INSERT INTO item (date, name, price, category, type)
+      VALUES (${date}, ${name}, ${price}, ${category}, ${type})
       RETURNING id
     `;
     return NextResponse.json({ success: true, id: result[0].id });
@@ -58,5 +61,11 @@ function validateData(data: any) {
   if (!data) return "データがありません";
   if (!data.name || typeof data.name !== "string") return "nameが不正です";
   if (!data.price || isNaN(Number(data.price))) return "priceが不正です";
+  if (!ITEM_TYPES.includes(data.type)) return "typeが不正です";
+  if (
+    !data.category ||
+    !CATEGORIES_BY_TYPE[data.type as ItemType].includes(data.category)
+  )
+    return "categoryが不正です";
   return null;
 }

--- a/project/src/app/api/search/route.ts
+++ b/project/src/app/api/search/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
   }
   const sql = neon(connectionString);
   try {
-    const items = await sql`SELECT id, date, name, price FROM item ORDER BY id`;
+    const items = await sql`SELECT id, date, name, price, category, type FROM item ORDER BY id`;
     return NextResponse.json({ success: true, items });
   } catch (e: unknown) {
     return NextResponse.json({ success: false, error: String(e) });

--- a/project/src/app/api/update/route.ts
+++ b/project/src/app/api/update/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { neon } from "@neondatabase/serverless";
+import { CATEGORIES_BY_TYPE, ITEM_TYPES, ItemType } from "@/lib/categories";
 
 export const runtime = "edge";
 
@@ -37,11 +38,13 @@ export async function PUT(request: Request) {
   const price = Number.parseInt(data.price);
   const name = data.name;
   const date = new Date(data.date).toISOString();
+  const type = data.type as ItemType;
+  const category = data.category;
 
   try {
     const result = await sql`
       UPDATE item
-      SET date = ${date}, name = ${name}, price = ${price}
+      SET date = ${date}, name = ${name}, price = ${price}, category = ${category}, type = ${type}
       WHERE id = ${id}
       RETURNING id
     `;
@@ -65,5 +68,11 @@ function validateData(data: any) {
   if (!data.id || isNaN(Number(data.id))) return "idが不正です";
   if (!data.name || typeof data.name !== "string") return "nameが不正です";
   if (!data.price || isNaN(Number(data.price))) return "priceが不正です";
+  if (!ITEM_TYPES.includes(data.type)) return "typeが不正です";
+  if (
+    !data.category ||
+    !CATEGORIES_BY_TYPE[data.type as ItemType].includes(data.category)
+  )
+    return "categoryが不正です";
   return null;
 }

--- a/project/src/app/entry/page.tsx
+++ b/project/src/app/entry/page.tsx
@@ -8,16 +8,31 @@ const styles = {
 };
 
 import React, { useState } from "react";
+import { CATEGORIES_BY_TYPE, ITEM_TYPES, ItemType } from "@/lib/categories";
 
 export default function Confirm() {
   // state
-  const [form, setForm] = useState({ date: "", name: "", price: "" });
+  const [form, setForm] = useState({
+    date: "",
+    name: "",
+    price: "",
+    type: ITEM_TYPES[0] as ItemType,
+    category: CATEGORIES_BY_TYPE[ITEM_TYPES[0]][0],
+  });
   const [message, setMessage] = useState("");
 
   // 入力欄が変更されたときに呼ばれる関数
   // e.target.nameに対応する値を更新する(既存のformの値を上書き)
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
     setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  // 収支種別が変更されたときは、選択中のカテゴリをその種別の先頭カテゴリにリセットする
+  const handleTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const type = e.target.value as ItemType;
+    setForm({ ...form, type, category: CATEGORIES_BY_TYPE[type][0] });
   };
 
   // フォームが送信されたときに呼ばれる関数
@@ -42,13 +57,51 @@ export default function Confirm() {
     );
     // 送信成功時はフォームをクリア
     if (data.success) {
-      setForm({ date: "", name: "", price: "" });
+      setForm({
+        date: "",
+        name: "",
+        price: "",
+        type: ITEM_TYPES[0],
+        category: CATEGORIES_BY_TYPE[ITEM_TYPES[0]][0],
+      });
     }
   };
 
   return (
     // フォーム：onSubmitでhandleSubmitが呼び出し
     <form onSubmit={handleSubmit} className={styles.form}>
+      <label className={styles.label} htmlFor="type">
+        収支種別
+        <select
+          id="type"
+          name="type"
+          value={form.type}
+          onChange={handleTypeChange}
+          className={styles.input}
+        >
+          {ITEM_TYPES.map((type) => (
+            <option key={type} value={type}>
+              {type}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className={styles.label} htmlFor="category">
+        カテゴリ
+        <select
+          id="category"
+          name="category"
+          value={form.category}
+          onChange={handleChange}
+          className={styles.input}
+        >
+          {CATEGORIES_BY_TYPE[form.type].map((category) => (
+            <option key={category} value={category}>
+              {category}
+            </option>
+          ))}
+        </select>
+      </label>
       <label className={styles.label} htmlFor="date">
         日付
         <input

--- a/project/src/app/list/page.tsx
+++ b/project/src/app/list/page.tsx
@@ -18,6 +18,7 @@ const styles = {
 // useEffect:ライフサイクル管理用
 // useState:状態管理用
 import React, { useEffect, useState } from "react";
+import { CATEGORIES_BY_TYPE, ITEM_TYPES, ItemType } from "@/lib/categories";
 
 // APIから取得の型定義
 type Item = {
@@ -25,6 +26,8 @@ type Item = {
   date: string;
   name: string;
   price: number;
+  category: string;
+  type: ItemType;
 };
 
 export default function EntryList() {
@@ -36,7 +39,13 @@ export default function EntryList() {
   // 編集中の行id(nullなら編集していない)
   const [editingId, setEditingId] = useState<number | null>(null);
   // 編集中の入力値
-  const [editForm, setEditForm] = useState({ date: "", name: "", price: "" });
+  const [editForm, setEditForm] = useState({
+    date: "",
+    name: "",
+    price: "",
+    type: ITEM_TYPES[0] as ItemType,
+    category: CATEGORIES_BY_TYPE[ITEM_TYPES[0]][0],
+  });
   // 保存・削除時のエラーメッセージ
   const [actionError, setActionError] = useState("");
 
@@ -73,6 +82,8 @@ export default function EntryList() {
       date: item.date.slice(0, 10),
       name: item.name,
       price: String(item.price),
+      type: item.type,
+      category: item.category,
     });
   };
 
@@ -81,8 +92,16 @@ export default function EntryList() {
     setActionError("");
   };
 
-  const handleEditChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleEditChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
     setEditForm({ ...editForm, [e.target.name]: e.target.value });
+  };
+
+  // 収支種別が変更されたときは、選択中のカテゴリをその種別の先頭カテゴリにリセットする
+  const handleEditTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const type = e.target.value as ItemType;
+    setEditForm({ ...editForm, type, category: CATEGORIES_BY_TYPE[type][0] });
   };
 
   // 編集内容を保存
@@ -103,6 +122,8 @@ export default function EntryList() {
                 date: new Date(editForm.date).toISOString(),
                 name: editForm.name,
                 price: Number.parseInt(editForm.price),
+                category: editForm.category,
+                type: editForm.type,
               }
             : item
         )
@@ -148,6 +169,8 @@ export default function EntryList() {
               <th className={styles.th}>日付</th>
               <th className={styles.th}>名前</th>
               <th className={styles.th}>金額</th>
+              <th className={styles.th}>種別</th>
+              <th className={styles.th}>カテゴリ</th>
               <th className={styles.th}>操作</th>
             </tr>
           </thead>
@@ -182,6 +205,34 @@ export default function EntryList() {
                     />
                   </td>
                   <td className={styles.td}>
+                    <select
+                      name="type"
+                      value={editForm.type}
+                      onChange={handleEditTypeChange}
+                      className={styles.input}
+                    >
+                      {ITEM_TYPES.map((type) => (
+                        <option key={type} value={type}>
+                          {type}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+                  <td className={styles.td}>
+                    <select
+                      name="category"
+                      value={editForm.category}
+                      onChange={handleEditChange}
+                      className={styles.input}
+                    >
+                      {CATEGORIES_BY_TYPE[editForm.type].map((category) => (
+                        <option key={category} value={category}>
+                          {category}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+                  <td className={styles.td}>
                     <button
                       className={styles.button}
                       onClick={() => saveEdit(item.id)}
@@ -207,6 +258,8 @@ export default function EntryList() {
                   </td>
                   <td className={styles.editableTd}>{item.name}</td>
                   <td className={styles.editableTd}>{item.price}</td>
+                  <td className={styles.editableTd}>{item.type}</td>
+                  <td className={styles.editableTd}>{item.category}</td>
                   <td className={styles.td}>
                     <button
                       className={styles.button}

--- a/project/src/lib/categories.ts
+++ b/project/src/lib/categories.ts
@@ -1,0 +1,20 @@
+export const ITEM_TYPES = ["支出", "収入"] as const;
+export type ItemType = (typeof ITEM_TYPES)[number];
+
+export const CATEGORIES_BY_TYPE: Record<ItemType, string[]> = {
+  支出: [
+    "食費",
+    "日用品",
+    "交通費",
+    "交際費",
+    "娯楽費",
+    "光熱費",
+    "通信費",
+    "住居費",
+    "医療費",
+    "被服費",
+    "教育費",
+    "その他",
+  ],
+  収入: ["給与", "賞与", "副収入", "その他"],
+};


### PR DESCRIPTION
## Summary
- item.category / item.type を追加(マイグレーション作成のみ、本番未適用)
- /api/insert, /api/update, /api/search をcategory/type対応に更新
- /entryフォームに収支種別・カテゴリの選択欄を追加
- /list画面の表示・インライン編集にcategory/typeを追加

Closes #20

## Test plan
- [x] ローカルDB + Prisma Clientで insert(category/type込み)・デフォルト値・update が期待通り動作することを確認
- [x] TypeScript型チェック(`tsc --noEmit`)がパスすることを確認
- [x] /entry画面で収支種別・カテゴリのセレクトボックスが表示されることを確認
- [ ] 本番Neon DBへのマイグレーション適用(マージ前に別途確認予定)
- [ ] 本番相当環境でのブラウザ実動作確認