### PR TITLE
ドキュメント整備とフォルダ構成の整理

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## プロジェクト概要
+
+家計簿アプリ。アプリのコードはすべて `project/`(Next.js + Prisma + Neon Postgres)に置いており、リポジトリ直下にはこのファイルとCI設定以外のコードはない。
+
+## コマンド
+
+すべて `project/` から実行する。
+
+```bash
+yarn install
+yarn dev          # next dev --turbopack, http://localhost:3000
+yarn build        # next build(PRの必須CIチェックと同じ)
+yarn start
+yarn lint
+npx tsc --noEmit  # 型チェック。専用スクリプトはない
+```
+
+このリポジトリにテストスイートはない。
+
+Prisma(スキーマ・マイグレーション管理のみ。ランタイムで使わない理由は後述):
+
+```bash
+npx prisma migrate dev --name <name>   # マイグレーションを作成・適用(ローカルPostgres)
+npx prisma migrate deploy              # 未適用のマイグレーションを本番に適用
+npx prisma generate                    # src/generated/prisma(gitignore対象)にクライアントを再生成
+```
+
+### ホストにLinux用Node.jsがない場合
+
+ホストマシンにLinux用のNode.js/npm/yarnが入っていないことがある(WSL経由でWindows側のnodeが見えるがパス変換で失敗する。またNext.jsのEdge Runtimeサンドボックスでは`pg`のようなものはそもそも動かない)。代わりにdevcontainerを使う。
+
+```bash
+docker start kakeibo_devcontainer-app-1   # コンテナ名は環境によって異なる場合がある。`docker ps -a`で確認
+docker exec kakeibo_devcontainer-app-1 sh -c "cd /workspaces/kakeibo/project && <command>"
+```
+
+devcontainerの`app`サービスは`db`サービスとネットワーク名前空間を共有している(`.devcontainer/docker-compose.yml`の`network_mode: service:db`)。そのため`app`コンテナ内から`localhost:5432`でローカルPostgresに直接アクセスできる。
+
+## 重要な制約: Edge Runtimeのため`neon()`を使っている(Prisma/`pg`は使えない)
+
+`src/app/api/*/route.ts` 配下の全ルートは `export const runtime = "edge"` を宣言している。これはCloudflare Pagesに`@cloudflare/next-on-pages`経由でデプロイするために必須(`wrangler.toml`参照)。next-on-pagesの関数はEdge Runtimeでしか動かない。
+
+Edge Runtime(実際のCloudflare Workersも、Next.jsのローカル開発用サンドボックスも)は生のTCP/TLSソケット(`net`/`tls`)を扱えない。このため標準の`pg`ドライバ(実際に試したところ`Module not found: Can't resolve 'util/types'`でビルド失敗することを確認済み)や、Prisma Clientの標準クエリエンジンは使えない。そのため各APIルートは、SQLをHTTPS fetch経由で実行する`@neondatabase/serverless`の`neon()`タグ付きテンプレート関数を使って直接SQLを書いている。
+
+**`neon()`は実際のNeonクラウドエンドポイントに対してしか動作しない。** 素のローカルPostgresには接続できず、`NeonDbError: ... TypeError: fetch failed`で失敗する。ローカルPostgresに対してこのエラーが出るのは想定通りの制約であり、追いかけて直すべきバグではない。
+
+`prisma/schema.prisma` と `prisma/migrations/` は引き続きDBスキーマの正とする(source of truth)。Prisma Clientは`src/generated/prisma`(gitignore対象)に生成されるが、上記の理由によりAPIルートのランタイムでは使っていない。`@prisma/adapter-neon`はインストールされているが配線されていない依存関係で、これを配線してもローカル開発の問題は解決しない(内部的には結局Neon独自のHTTP/WSプロトコルを使うため、素のPostgresワイヤープロトコルには対応しない)。
+
+本番に触れずにスキーマ・クエリのロジックをローカルで検証したい場合は、Next.jsのルートを経由せず、素の`node`で実行する使い捨てスクリプトの中でPrisma Clientを直接使うとよい。Prismaの標準エンジンは通常のPostgresワイヤー接続を使うため、ローカルのdocker-compose Postgresに対して問題なく動く。
+
+## 本番DBについて: 開発用DBとの分離なし
+
+`project/.env`の`DATABASE_URL`は実際の本番Neon DBを指しており、ステージング用DBは存在しない。docker-composeの`db`サービス(`postgresql://postgres:postgres@localhost:5432/postgres`)がローカル実験の唯一安全な接続先。ローカルでスクリプトやPrismaコマンドを実行する際は**`DATABASE_URL`を明示的に上書きする**こと。上書きしないと気づかないうちに本番に接続してしまう。
+
+スキーマ変更の進め方: まずローカルPostgresに対してマイグレーションを作成・適用(`prisma migrate dev`)し、レビュー・マージを経てから、本番への適用(`prisma migrate deploy`)は別途行う。これは自動的に行わず、実行前に必ず確認を取るべき高リスクな操作として扱うこと。
+
+本番の`item`テーブルはPrismaのマイグレーション記録なしに事前に存在していたため、一度だけ`prisma migrate resolve --applied <migration>`によるbaseline(既に適用済みとして記録する操作)が必要だった。`prisma migrate status`で、実際にはスキーマに反映済みのはずの古いマイグレーションが「未適用」と表示された場合は、この経緯が原因。
+
+## アプリの構成
+
+- `src/app/page.tsx` — トップページ。`/entry`と`/list`へのリンク
+- `src/app/entry/page.tsx` — 収支を追加するフォーム(クライアントコンポーネント、`/api/insert`にPOST)
+- `src/app/list/page.tsx` — 一覧画面。行をクリックしてその場編集(`/api/update`/`/api/delete`を呼ぶ)、収入/支出/差引の合計サマリー表示
+- `src/app/api/{search,insert,update,delete}/route.ts` — `item`テーブル(`id`, `date`, `name`, `price`, `category`, `type`)に対するCRUD
+- `src/lib/categories.ts` — 収支種別`ITEM_TYPES`(収入/支出)とカテゴリ候補`CATEGORIES_BY_TYPE`を共有定義。APIのバリデーションとentry/list画面のUI両方から参照することで、クライアント/サーバー間でカテゴリの許容値がずれないようにしている
+- `src/app/layout.tsx` — 全ページ共通のヘッダー・ナビゲーション
+
+APIルートは全て `{ success: boolean, ... }` 形式のJSONを返す。失敗時は `{ success: false, error: string }` をHTTP 200で返す(エラーステータスコードは使わない)。
+
+## Gitワークフロー
+
+GitHub Flow: GitHub Issueに対応する `feature/#<issue番号>` という名前のブランチ(例: `feature/#15`)を切り、`main`へPRを出す。`main`はブランチ保護されており、直pushは禁止、ビルド成功(`.github/workflows/pr-build.yml`、`project/`で`yarn build`を実行)が必須。PR本文で `Closes #N` によりissueを参照する。

--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
+# 家計簿
+
+日々の収支をシンプルに記録・確認できる家計簿アプリです。
+
+## 機能
+
+- 収支の入力(日付・内容・金額・収支種別・カテゴリ)
+- 一覧表示(行クリックでその場編集、削除)
+- 収入・支出・差引の合計サマリー表示
+
+## フォルダ構成
+
+```
+.
+├── CLAUDE.md          # Claude Code向けの開発ガイド
+├── README.md          # このファイル
+├── .devcontainer/     # 開発用コンテナ設定(Node.js + ローカルPostgres)
+├── .github/workflows/ # PRビルドチェック(GitHub Actions)
+└── project/           # アプリ本体(Next.js)
+    ├── src/app/       # ページ・APIルート(App Router)
+    ├── src/lib/       # 共有ロジック(カテゴリ定義など)
+    └── prisma/        # DBスキーマ・マイグレーション
+```
+
+アプリのコードはすべて `project/` 配下にあります。
+
 ## このプロジェクトで使っている技術
 
 ### フロントエンド
@@ -18,7 +44,7 @@
 
 ### バックエンド
 
-- Prisma（ORM/データベース操作）  
+- Prisma（ORM/データベース操作、スキーマ・マイグレーション管理用）  
   TypeScript でデータベースを操作できる
 
 ### データベース
@@ -26,3 +52,17 @@
 - PostgreSQL（データベース）
 - Neon（サーバーレス PostgreSQL）  
   サーバーレスで PostgreSQL サービスを使用できる
+
+## 開発環境
+
+VS Code の Dev Containers 拡張機能で `.devcontainer` を開くと、Node.js とローカル用PostgreSQLコンテナが立ち上がります。
+
+```bash
+cd project
+yarn install
+yarn dev
+```
+
+`http://localhost:3000` で確認できます。
+
+DB接続まわりの制約(Edge Runtime・本番/ローカルDBの分離)や開発時の注意点は [CLAUDE.md](./CLAUDE.md) にまとめています。

--- a/project/README.md
+++ b/project/README.md
@@ -1,36 +1,21 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+Next.js (App Router) 製の家計簿アプリ本体です。プロジェクト全体の概要は [ルートのREADME](../README.md) を、開発時の注意点は [CLAUDE.md](../CLAUDE.md) を参照してください。
 
-## Getting Started
-
-First, run the development server:
+## セットアップ
 
 ```bash
-npm run dev
-# or
+yarn install
 yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+[http://localhost:3000](http://localhost:3000) で確認できます。
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## 主なコマンド
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+yarn dev          # 開発サーバー起動(Turbopack)
+yarn build        # 本番ビルド(PRのCIチェックと同じ)
+yarn lint         # ESLint
+npx tsc --noEmit  # 型チェック
+```
 
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+DBスキーマ変更時は `npx prisma migrate dev --name <name>` でマイグレーションを作成します。本番DBへの適用(`prisma migrate deploy`)は別途確認のうえ行ってください。

--- a/project/prisma/schema.prisma
+++ b/project/prisma/schema.prisma
@@ -14,11 +14,14 @@ datasource db {
   url      = env("DATABASE_URL")
 }   
 
+// 家計簿の1件の収支レコード。
+// このスキーマ・マイグレーションはDB構造管理のためだけに使っており、
+// 実際のAPI(insert/update/search/delete)はEdge Runtime対応のためPrisma Clientではなくneon()直SQLを使っている(詳細はCLAUDE.md参照)
 model item {
   id       Int      @id @default(autoincrement())
   date     DateTime
   name     String
   price    Int
-  category String   @default("その他")
-  type     String   @default("支出")
+  category String   @default("その他") // src/lib/categories.tsのCATEGORIES_BY_TYPEと対応
+  type     String   @default("支出") // "支出" または "収入" (src/lib/categories.tsのITEM_TYPES)
 }

--- a/project/src/app/api/delete/route.ts
+++ b/project/src/app/api/delete/route.ts
@@ -1,10 +1,13 @@
 import { NextResponse } from "next/server";
 import { neon } from "@neondatabase/serverless";
 
+// Edge Runtimeで動かす理由は src/app/api/insert/route.ts のコメント・CLAUDE.md参照
 export const runtime = "edge";
 
 /**
  * itemテーブルのレコードを削除するAPIエンドポイント
+ * DELETE /api/delete
+ * (/list画面の削除ボタンから呼ばれる)
  */
 export async function DELETE(request: Request) {
   let data;
@@ -33,6 +36,7 @@ export async function DELETE(request: Request) {
   const id = Number.parseInt(data.id);
 
   try {
+    // 削除できた行のidが返ってくるので、0件なら対象なしと判断できる
     const result = await sql`
       DELETE FROM item WHERE id = ${id} RETURNING id
     `;

--- a/project/src/app/api/insert/route.ts
+++ b/project/src/app/api/insert/route.ts
@@ -2,12 +2,17 @@ import { NextResponse } from "next/server";
 import { neon } from "@neondatabase/serverless";
 import { CATEGORIES_BY_TYPE, ITEM_TYPES, ItemType } from "@/lib/categories";
 
+// Cloudflare Pages(next-on-pages)にデプロイするため、このAPIルートはEdge Runtimeで動く。
+// Edge Runtimeは生のTCP/TLSソケットを扱えないため、通常のpgドライバやPrisma標準エンジンは使えない。
+// そのためDBアクセスにはHTTPS fetch経由でSQLを実行するneon()を使っている(詳細はCLAUDE.md参照)。
 export const runtime = "edge";
 
 /**
  * itemテーブルにデータを挿入するAPIエンドポイント
+ * POST /api/insert
  */
 export async function POST(request: Request) {
+  // リクエストボディをJSONとしてパース
   let data;
   try {
     data = await request.json();
@@ -18,12 +23,13 @@ export async function POST(request: Request) {
     });
   }
 
+  // 入力値のチェック(不正な場合はエラーメッセージを返して終了)
   const validationError = validateData(data);
   if (validationError) {
     return NextResponse.json({ success: false, error: validationError });
   }
 
-  // DB接続文字列を取得
+  // DB接続文字列を取得(project/.envのDATABASE_URLは本番Neon DBを指しているので注意)
   const connectionString = process.env.DATABASE_URL;
   if (!connectionString) {
     return NextResponse.json({
@@ -36,6 +42,7 @@ export async function POST(request: Request) {
   // 各値を適切な型に変換
   const price = Number.parseInt(data.price);
   const name = data.name;
+  // 日付未指定の場合は現在時刻を使う
   const date = data.date
     ? new Date(data.date).toISOString()
     : new Date().toISOString();
@@ -43,6 +50,7 @@ export async function POST(request: Request) {
   const category = data.category;
 
   try {
+    // idはDB側でautoincrementのため指定しない。挿入結果のidをRETURNINGで受け取る
     const result = await sql`
       INSERT INTO item (date, name, price, category, type)
       VALUES (${date}, ${name}, ${price}, ${category}, ${type})
@@ -56,12 +64,14 @@ export async function POST(request: Request) {
 
 /**
  * データのバリデーションを行う関数
+ * 問題があればエラーメッセージ(文字列)を、問題なければnullを返す
  */
 function validateData(data: any) {
   if (!data) return "データがありません";
   if (!data.name || typeof data.name !== "string") return "nameが不正です";
   if (!data.price || isNaN(Number(data.price))) return "priceが不正です";
   if (!ITEM_TYPES.includes(data.type)) return "typeが不正です";
+  // categoryは選択中のtypeに対応する候補一覧に含まれているかをチェックする
   if (
     !data.category ||
     !CATEGORIES_BY_TYPE[data.type as ItemType].includes(data.category)

--- a/project/src/app/api/search/route.ts
+++ b/project/src/app/api/search/route.ts
@@ -1,8 +1,14 @@
 import { NextResponse } from "next/server";
 import { neon } from "@neondatabase/serverless";
 
+// Edge Runtimeで動かす理由は src/app/api/insert/route.ts のコメント・CLAUDE.md参照
 export const runtime = "edge";
 
+/**
+ * item一覧を取得するAPIエンドポイント
+ * GET /api/search
+ * (/list画面の初期表示で呼ばれる)
+ */
 export async function GET() {
   const connectionString = process.env.DATABASE_URL;
   if (!connectionString) {
@@ -13,6 +19,7 @@ export async function GET() {
   }
   const sql = neon(connectionString);
   try {
+    // idの昇順(登録順)ですべて取得する
     const items = await sql`SELECT id, date, name, price, category, type FROM item ORDER BY id`;
     return NextResponse.json({ success: true, items });
   } catch (e: unknown) {

--- a/project/src/app/api/update/route.ts
+++ b/project/src/app/api/update/route.ts
@@ -2,10 +2,13 @@ import { NextResponse } from "next/server";
 import { neon } from "@neondatabase/serverless";
 import { CATEGORIES_BY_TYPE, ITEM_TYPES, ItemType } from "@/lib/categories";
 
+// Edge Runtimeで動かす理由は src/app/api/insert/route.ts のコメント・CLAUDE.md参照
 export const runtime = "edge";
 
 /**
  * itemテーブルの既存レコードを更新するAPIエンドポイント
+ * PUT /api/update
+ * (/list画面で行をクリックして編集・保存したときに呼ばれる)
  */
 export async function PUT(request: Request) {
   let data;
@@ -42,6 +45,7 @@ export async function PUT(request: Request) {
   const category = data.category;
 
   try {
+    // 指定idの行を全項目まとめて更新。該当行がなければ0件で返ってくる
     const result = await sql`
       UPDATE item
       SET date = ${date}, name = ${name}, price = ${price}, category = ${category}, type = ${type}
@@ -62,6 +66,7 @@ export async function PUT(request: Request) {
 
 /**
  * データのバリデーションを行う関数
+ * 問題があればエラーメッセージ(文字列)を、問題なければnullを返す
  */
 function validateData(data: any) {
   if (!data) return "データがありません";

--- a/project/src/app/entry/page.tsx
+++ b/project/src/app/entry/page.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+// 収支入力フォーム画面(/entry)。入力内容を/api/insertにPOSTして登録する
+
+// スタイルをオブジェクトで管理(Tailwindのクラス名をまとめておくと使い回しやすい)
 const styles = {
   card: "max-w-md mx-auto bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl shadow-sm p-6 space-y-5",
   title: "text-xl font-bold text-center",

--- a/project/src/app/layout.tsx
+++ b/project/src/app/layout.tsx
@@ -27,6 +27,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100 min-h-screen`}
       >
+        {/* 全ページ共通のヘッダー(サイトタイトル+ナビゲーション) */}
         <header className="border-b border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-900/80 backdrop-blur sticky top-0 z-10">
           <div className="max-w-3xl mx-auto px-4 py-3 flex items-center justify-between">
             <a

--- a/project/src/app/list/page.tsx
+++ b/project/src/app/list/page.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+// 一覧画面(/list)。/api/searchで取得した一覧を表示し、行クリックでその場編集(/api/update)、
+// 削除ボタンで削除(/api/delete)できる。収入/支出/差引の合計サマリーも表示する
+
 // スタイルをオブジェクトで管理
 const styles = {
   title: "text-xl font-bold mb-4",

--- a/project/src/app/page.tsx
+++ b/project/src/app/page.tsx
@@ -1,3 +1,4 @@
+// トップページ。入力画面(/entry)と一覧画面(/list)へのリンクカードを並べるだけのシンプルな構成
 export default function Home() {
   return (
     <div className="flex flex-col items-center text-center gap-10 py-12">

--- a/project/src/lib/categories.ts
+++ b/project/src/lib/categories.ts
@@ -1,6 +1,10 @@
+// 収支種別(支出/収入)の一覧。配列の並び順がUIの選択肢の順番にもなる
 export const ITEM_TYPES = ["支出", "収入"] as const;
 export type ItemType = (typeof ITEM_TYPES)[number];
 
+// 収支種別ごとのカテゴリ候補一覧。
+// entry/list画面のカテゴリ選択肢と、APIのバリデーション(insert/update)の両方でここを参照することで、
+// クライアントとサーバーでカテゴリの許容値がずれないようにしている。
 export const CATEGORIES_BY_TYPE: Record<ItemType, string[]> = {
   支出: [
     "食費",


### PR DESCRIPTION
## Summary
- CLAUDE.mdを新規作成(Claude Code向け開発ガイド、日本語)。Edge Runtime制約・本番/ローカルDB分離など、これまでの経緯で分かった注意点をまとめた
- README.mdをプロジェクト概要・フォルダ構成・起動手順付きに拡充、project/README.mdもテンプレートのままだった内容を実プロジェクト向けに書き換え
- リポジトリ直下の未使用の空フォルダ(api/, functions/, react-app/)と、対応するpackage.jsonのない孤立したnode_modules/prismaを削除(いずれもgit管理外)
- API(insert/update/delete/search)・src/lib/categories.ts・prisma/schema.prismaに説明コメントを追加

コード・DB・APIの挙動自体は変更なし(ドキュメント・コメント・不要ファイル整理のみ)。

## Test plan
- [x] `tsc --noEmit` がエラーなしでパスすることを確認