### PR TITLE
一覧画面: 月別絞り込み・カテゴリ別集計グラフ・検索/並び替え

### DIFF
--- a/project/src/app/list/page.tsx
+++ b/project/src/app/list/page.tsx
@@ -1,17 +1,25 @@
 "use client";
 
 // 一覧画面(/list)。/api/searchで取得した一覧を表示し、行クリックでその場編集(/api/update)、
-// 削除ボタンで削除(/api/delete)できる。収入/支出/差引の合計サマリーも表示する
+// 削除ボタンで削除(/api/delete)できる。
+// 月別の絞り込み・検索・並び替えができ、収入/支出/差引の合計サマリーとカテゴリ別集計グラフは
+// いずれも絞り込み後のデータを対象にする(フィルタは一覧より上の1箇所にまとめて配置)
 
 // スタイルをオブジェクトで管理
 const styles = {
   title: "text-xl font-bold mb-4",
+  filterBar:
+    "flex flex-wrap items-center gap-2 mb-4 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-3 shadow-sm",
+  filterInput:
+    "rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-950 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:focus:ring-indigo-600",
   summaryCard:
     "grid grid-cols-3 gap-3 mb-6 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-4 shadow-sm",
   summaryLabel: "text-xs text-slate-500 dark:text-slate-400",
   summaryIncome: "text-lg font-bold text-emerald-600 dark:text-emerald-400",
   summaryExpense: "text-lg font-bold text-rose-600 dark:text-rose-400",
   summaryBalance: "text-lg font-bold",
+  chartCard:
+    "grid grid-cols-1 sm:grid-cols-2 gap-6 mb-6 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-4 shadow-sm",
   tableWrap:
     "rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 shadow-sm overflow-hidden",
   table: "w-full text-sm",
@@ -44,8 +52,9 @@ const styles = {
 // Reactフック
 // useEffect:ライフサイクル管理用
 // useState:状態管理用
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { CATEGORIES_BY_TYPE, ITEM_TYPES, ItemType } from "@/lib/categories";
+import { CategoryBarChart } from "@/components/CategoryBarChart";
 
 // APIから取得の型定義
 type Item = {
@@ -57,11 +66,29 @@ type Item = {
   type: ItemType;
 };
 
+type SortKey = "date" | "price";
+type SortOrder = "asc" | "desc";
+
+// dateの先頭7文字("YYYY-MM")を月のキーとして使う
+const toMonthKey = (dateStr: string) => dateStr.slice(0, 7);
+
+// "YYYY-MM" -> "YYYY年M月" の表示用ラベルに変換する
+const formatMonthLabel = (monthKey: string) => {
+  const [year, month] = monthKey.split("-");
+  return `${year}年${Number(month)}月`;
+};
+
 export default function EntryList() {
   // この辺よくわからないが動く状態達
   const [items, setItems] = useState<Item[]>([]); //データの配列
   const [loading, setLoading] = useState(true); //ローディングかどうか
   const [error, setError] = useState(""); //エラーメッセージ
+
+  // 絞り込み・検索・並び替えの状態。selectedMonthは"all"かYYYY-MM
+  const [selectedMonth, setSelectedMonth] = useState("all");
+  const [searchText, setSearchText] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("date");
+  const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
 
   // 編集中の行id(nullなら編集していない)
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -89,6 +116,9 @@ export default function EntryList() {
         const data = await res.json();
         if (data.success) {
           setItems(data.items);
+          // デフォルトの絞り込みを当月にする(サーバー/クライアントで日付がずれないよう
+          // 初期状態は"all"にしておき、データ取得後にここで当月へ切り替える)
+          setSelectedMonth(toMonthKey(new Date().toISOString()));
         } else {
           setError(data.error || "データ取得に失敗しました");
         }
@@ -100,6 +130,32 @@ export default function EntryList() {
     };
     fetchData(); // データ取得実行
   }, []);
+
+  // 一覧に登場する月の一覧(新しい順)。データがない当月分も選べるよう別途追加する
+  const monthOptions = useMemo(() => {
+    const months = new Set(items.map((item) => toMonthKey(item.date)));
+    months.add(toMonthKey(new Date().toISOString()));
+    return Array.from(months).sort((a, b) => (a < b ? 1 : -1));
+  }, [items]);
+
+  // 月・検索の絞り込みを適用した一覧
+  const filteredItems = useMemo(() => {
+    return items.filter((item) => {
+      if (selectedMonth !== "all" && toMonthKey(item.date) !== selectedMonth)
+        return false;
+      if (searchText && !item.name.includes(searchText)) return false;
+      return true;
+    });
+  }, [items, selectedMonth, searchText]);
+
+  // 表示用に並び替えたもの(元の配列は変更しない)
+  const sortedItems = useMemo(() => {
+    const sign = sortOrder === "asc" ? 1 : -1;
+    return [...filteredItems].sort((a, b) => {
+      if (sortKey === "price") return (a.price - b.price) * sign;
+      return (a.date < b.date ? -1 : a.date > b.date ? 1 : 0) * sign;
+    });
+  }, [filteredItems, sortKey, sortOrder]);
 
   // 行クリックで編集モードに入る
   const startEdit = (item: Item) => {
@@ -179,14 +235,24 @@ export default function EntryList() {
     }
   };
 
-  // 収入・支出・差引の合計
-  const totalIncome = items
+  // 収入・支出・差引の合計(絞り込み後のデータが対象)
+  const totalIncome = filteredItems
     .filter((item) => item.type === "収入")
     .reduce((sum, item) => sum + item.price, 0);
-  const totalExpense = items
+  const totalExpense = filteredItems
     .filter((item) => item.type === "支出")
     .reduce((sum, item) => sum + item.price, 0);
   const balance = totalIncome - totalExpense;
+
+  // カテゴリ別集計(支出・収入それぞれ、絞り込み後のデータが対象)
+  const categoryTotals = (type: ItemType) => {
+    const totals = new Map<string, number>();
+    for (const item of filteredItems) {
+      if (item.type !== type) continue;
+      totals.set(item.category, (totals.get(item.category) ?? 0) + item.price);
+    }
+    return Array.from(totals, ([category, total]) => ({ category, total }));
+  };
 
   // 画面描画
   return (
@@ -199,6 +265,48 @@ export default function EntryList() {
         <div className={styles.error}>{error}</div>
       ) : (
         <>
+          {/* 絞り込み・検索・並び替え。ここでの選択が下のサマリー・グラフ・一覧すべてに反映される */}
+          <div className={styles.filterBar}>
+            <select
+              value={selectedMonth}
+              onChange={(e) => setSelectedMonth(e.target.value)}
+              className={styles.filterInput}
+              aria-label="表示する月"
+            >
+              <option value="all">すべての期間</option>
+              {monthOptions.map((month) => (
+                <option key={month} value={month}>
+                  {formatMonthLabel(month)}
+                </option>
+              ))}
+            </select>
+            <input
+              value={searchText}
+              onChange={(e) => setSearchText(e.target.value)}
+              placeholder="内容で検索"
+              className={styles.filterInput}
+              aria-label="内容で検索"
+            />
+            <select
+              value={`${sortKey}-${sortOrder}`}
+              onChange={(e) => {
+                const [key, order] = e.target.value.split("-") as [
+                  SortKey,
+                  SortOrder
+                ];
+                setSortKey(key);
+                setSortOrder(order);
+              }}
+              className={styles.filterInput}
+              aria-label="並び替え"
+            >
+              <option value="date-desc">日付が新しい順</option>
+              <option value="date-asc">日付が古い順</option>
+              <option value="price-desc">金額が高い順</option>
+              <option value="price-asc">金額が低い順</option>
+            </select>
+          </div>
+
           <div className={styles.summaryCard}>
             <div>
               <div className={styles.summaryLabel}>収入</div>
@@ -220,8 +328,27 @@ export default function EntryList() {
             </div>
           </div>
 
-          {items.length === 0 ? (
-            <div className={styles.empty}>まだデータがありません</div>
+          {(totalExpense > 0 || totalIncome > 0) && (
+            <div className={styles.chartCard}>
+              <CategoryBarChart
+                title="カテゴリ別内訳(支出)"
+                data={categoryTotals("支出")}
+                barColorClassName="bg-rose-500"
+              />
+              <CategoryBarChart
+                title="カテゴリ別内訳(収入)"
+                data={categoryTotals("収入")}
+                barColorClassName="bg-emerald-500"
+              />
+            </div>
+          )}
+
+          {sortedItems.length === 0 ? (
+            <div className={styles.empty}>
+              {items.length === 0
+                ? "まだデータがありません"
+                : "条件に一致するデータがありません"}
+            </div>
           ) : (
             <div className={styles.tableWrap}>
               <table className={styles.table}>
@@ -235,7 +362,7 @@ export default function EntryList() {
                   </tr>
                 </thead>
                 <tbody>
-                  {items.map((item) =>
+                  {sortedItems.map((item) =>
                     editingId === item.id ? (
                       <tr key={item.id} className={styles.row}>
                         <td className={styles.td}>

--- a/project/src/components/CategoryBarChart.tsx
+++ b/project/src/components/CategoryBarChart.tsx
@@ -1,0 +1,54 @@
+// カテゴリ別集計を横棒グラフで表示するコンポーネント。
+// 単一の系列(1色)での大小比較なので、色は凡例なしの単色(sequential)で統一する。
+// 参考: dataviz skillのchoosing-a-form(「大小比較=bar、色はsequential一色」)
+
+const styles = {
+  container: "space-y-2",
+  title: "text-sm font-semibold text-slate-600 dark:text-slate-300 mb-2",
+  row: "flex items-center gap-2 group",
+  label: "w-16 sm:w-20 shrink-0 text-xs text-slate-600 dark:text-slate-300 truncate",
+  track: "flex-1 h-5 rounded bg-slate-100 dark:bg-slate-800 overflow-hidden",
+  value:
+    "w-20 shrink-0 text-xs text-right text-slate-700 dark:text-slate-200 tabular-nums",
+};
+
+export type CategoryTotal = { category: string; total: number };
+
+export function CategoryBarChart({
+  title,
+  data,
+  barColorClassName,
+}: {
+  title: string;
+  data: CategoryTotal[];
+  barColorClassName: string;
+}) {
+  if (data.length === 0) return null;
+
+  // 金額の大きい順に並べ替え、最大値を基準にバーの長さを決める
+  const sorted = [...data].sort((a, b) => b.total - a.total);
+  const max = sorted[0].total;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.title}>{title}</div>
+      {sorted.map((d) => (
+        <div
+          key={d.category}
+          className={styles.row}
+          title={`${d.category}: ${d.total.toLocaleString()}円`}
+        >
+          <div className={styles.label}>{d.category}</div>
+          <div className={styles.track}>
+            <div
+              className={`h-full rounded-r ${barColorClassName} group-hover:brightness-110 transition-[width]`}
+              style={{ width: `${max === 0 ? 0 : (d.total / max) * 100}%` }}
+            />
+          </div>
+          {/* 値はバーの端に添える形で、常に見える直接ラベルとして表示する */}
+          <div className={styles.value}>{d.total.toLocaleString()}円</div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 一覧画面(/list)に月選択(デフォルト当月、「すべての期間」も選択可)・内容検索・並び替え(日付/金額)のフィルタバーを追加
- 収入/支出/差引のサマリー、カテゴリ別集計グラフは、いずれも絞り込み後のデータを対象にする
- カテゴリ別集計は横棒グラフ(単色・直接ラベル、dataviz skillの「大小比較=bar、色はsequential一色」に基づく設計)で表示する`CategoryBarChart`コンポーネントを新規作成

DB・APIへの変更はなし(表示側のみ、`/api/search`の結果をクライアント側で絞り込み・集計)。

Closes #29

## Test plan
- [x] `tsc --noEmit`・`yarn lint`・`yarn test`(18件)がすべてパスすることを確認
- [x] `CategoryBarChart`をモックデータで一時的にプレビューし、バーの幅比率が金額に対して正しく計算されることを確認(住居費60,000円→100%、食費32,000円→53.3%など)
- [ ] 実データでのブラウザ確認は、`neon()`がローカルPostgresに接続できない制約により未実施(本番相当での確認を推奨)