### PR TITLE
CLAUDE.md/Skillsをテスト基盤導入後の実態に同期

### DIFF
--- a/.claude/skills/feature-branch/SKILL.md
+++ b/.claude/skills/feature-branch/SKILL.md
@@ -29,7 +29,7 @@ kakeiboのGitワークフロー(CLAUDE.md参照)を実行するスキル。GitHu
 2. リモートにpushする: `git push -u origin feature/#<issue番号>`
 3. PR本文に必ず `Closes #<issue番号>` を含め、何を・なぜ変更したかを簡潔にまとめる。
 4. `gh pr create --title "..." --body "$(cat <<'EOF' ... EOF)"` の形式でPRを作成する。
-5. CIは`.github/workflows/pr-build.yml`が`project/`で`yarn build`を実行する。事前に`project/`で`yarn build`を実行し、通ることを確認してからPRを作成するとやり直しが減る。
+5. CIは`.github/workflows/pr-build.yml`が`project/`で`yarn lint`・`yarn test`・`yarn build`を順に実行する。事前に`project/`でこの3つを実行し、通ることを確認してからPRを作成するとやり直しが減る。
 
 ## 注意
 

--- a/.claude/skills/new-api-route/SKILL.md
+++ b/.claude/skills/new-api-route/SKILL.md
@@ -24,7 +24,7 @@ description: kakeiboの既存のCRUD API規約(Edge Runtime、@neondatabase/serv
 2. `src/app/api/<新ルート名>/route.ts` を作成し、上記の規約に沿って実装する。HTTPメソッドは操作に応じて選ぶ(参照系はGET、作成はPOST、更新はPUT、削除はDELETE)。
 3. `item`テーブルにない列やテーブルを新たに使う場合は、`prisma/schema.prisma`にモデルを追加し、`npx prisma migrate dev --name <name>`でローカルにマイグレーションを作成する(本番への適用は別途ユーザー確認の上で行う。db-safety-guardianエージェントも参照)。
 4. フロントエンドから呼ぶ場合は、呼び出し側でも`{ success, error }`形式のレスポンスを想定したエラーハンドリングを行う。
-5. このリポジトリにテストスイートはないため、`project/`で`npx tsc --noEmit`と`yarn build`を実行して型・ビルドエラーがないことを確認する。実際に`yarn dev`で叩いて動作確認するとなお良い。
+5. `project/`で`npx tsc --noEmit`・`yarn lint`・`yarn test`・`yarn build`を実行してエラーがないことを確認する。`src/lib/validate.ts`に新しいバリデーションを追加した場合は、`validate.test.ts`に倣ってユニットテストも追加する。実際に`yarn dev`で叩いて動作確認するとなお良い。
 
 ## 注意
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,10 +16,11 @@ yarn dev          # next dev --turbopack, http://localhost:3000
 yarn build        # next build(PRの必須CIチェックと同じ)
 yarn start
 yarn lint
+yarn test         # vitest run。src/lib配下のロジック(validate.ts/categories.ts)のユニットテスト
 npx tsc --noEmit  # 型チェック。専用スクリプトはない
 ```
 
-このリポジトリにテストスイートはない。
+`yarn lint`・`yarn test`・`yarn build`はいずれも`.github/workflows/pr-build.yml`のPR必須チェック。Edge Runtime依存(`neon()`経由)のAPIルート自体はテスト対象外(詳細は後述)。
 
 Prisma(スキーマ・マイグレーション管理のみ。ランタイムで使わない理由は後述):
 
@@ -64,9 +65,11 @@ Edge Runtime(実際のCloudflare Workersも、Next.jsのローカル開発用サ
 
 - `src/app/page.tsx` — トップページ。`/entry`と`/list`へのリンク
 - `src/app/entry/page.tsx` — 収支を追加するフォーム(クライアントコンポーネント、`/api/insert`にPOST)
-- `src/app/list/page.tsx` — 一覧画面。行をクリックしてその場編集(`/api/update`/`/api/delete`を呼ぶ)、収入/支出/差引の合計サマリー表示
+- `src/app/list/page.tsx` — 一覧画面。行をクリックしてその場編集(`/api/update`/`/api/delete`を呼ぶ)、月別絞り込み・内容検索・並び替え(日付/金額)、収入/支出/差引の合計サマリー表示
 - `src/app/api/{search,insert,update,delete}/route.ts` — `item`テーブル(`id`, `date`, `name`, `price`, `category`, `type`)に対するCRUD
+- `src/lib/validate.ts` — insert/update/delete共通のバリデーション(`validateItemFields`/`validateId`)。ユニットテスト(`validate.test.ts`)あり
 - `src/lib/categories.ts` — 収支種別`ITEM_TYPES`(収入/支出)とカテゴリ候補`CATEGORIES_BY_TYPE`を共有定義。APIのバリデーションとentry/list画面のUI両方から参照することで、クライアント/サーバー間でカテゴリの許容値がずれないようにしている
+- `src/components/CategoryBarChart.tsx` — /list画面のカテゴリ別集計を表示する横棒グラフ(単色・直接ラベル。詳細は`docs/react-basics.md`ではなくdataviz skillの方針を参照)
 - `src/app/layout.tsx` — 全ページ共通のヘッダー・ナビゲーション
 
 APIルートは全て `{ success: boolean, ... }` 形式のJSONを返す。失敗時は `{ success: false, error: string }` をHTTP 200で返す(エラーステータスコードは使わない)。


### PR DESCRIPTION
## Summary
別セッションで追加されたAgents/Skills(db-safety-guardian, react-tutor, feature-branch, new-api-route)を確認したところ、CLAUDE.md本体とSkillsに、PR #28(vitest導入)・PR #30(一覧画面の絞り込み/グラフ)以前の古い記述が残っていたため同期した。

- CLAUDE.md: 「テストスイートはない」という誤った記述を修正し、`yarn test`をコマンド一覧に追加
- CLAUDE.md: 「アプリの構成」に`src/lib/validate.ts`・`src/components/CategoryBarChart.tsx`・一覧画面の月別絞り込み/検索/並び替えを追記
- `feature-branch`/`new-api-route` skill: PR作成前のチェック手順に`yarn lint`・`yarn test`を追加(CIが既にこの2つを実行するため)

Agent(`db-safety-guardian`・`react-tutor`)自体の内容は確認した範囲で問題なし、変更なし。

## Test plan
- [x] `tsc --noEmit`・`yarn lint`・`yarn test`(18件)がすべてパスすることを確認