### PR TITLE
予算設定・進捗表示の追加

### DIFF
--- a/project/prisma/migrations/20260708134822_add_budget/migration.sql
+++ b/project/prisma/migrations/20260708134822_add_budget/migration.sql
@@ -1,0 +1,7 @@
+-- CreateTable
+CREATE TABLE "budget" (
+    "category" TEXT NOT NULL,
+    "amount" INTEGER NOT NULL,
+
+    CONSTRAINT "budget_pkey" PRIMARY KEY ("category")
+);

--- a/project/prisma/schema.prisma
+++ b/project/prisma/schema.prisma
@@ -25,3 +25,10 @@ model item {
   category String   @default("その他") // src/lib/categories.tsのCATEGORIES_BY_TYPEと対応
   type     String   @default("支出") // "支出" または "収入" (src/lib/categories.tsのITEM_TYPES)
 }
+
+// 支出カテゴリごとの継続的な月間予算。月ごとの実績と突き合わせて/list画面に進捗表示する。
+// 予算は任意設定なので、このテーブルに行がないカテゴリは「未設定」を意味する。
+model budget {
+  category String @id // src/lib/categories.tsのCATEGORIES_BY_TYPE.支出のいずれか
+  amount   Int
+}

--- a/project/src/app/api/budget-delete/route.ts
+++ b/project/src/app/api/budget-delete/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { neon } from "@neondatabase/serverless";
+import { CATEGORIES_BY_TYPE } from "@/lib/categories";
+
+// Edge Runtimeで動かす理由は src/app/api/insert/route.ts のコメント・CLAUDE.md参照
+export const runtime = "edge";
+
+/**
+ * カテゴリの予算設定を削除する(「未設定」に戻す)APIエンドポイント
+ * DELETE /api/budget-delete
+ * (/budget画面で金額欄を空にして保存したときに呼ばれる)
+ */
+export async function DELETE(request: Request) {
+  let data;
+  try {
+    data = await request.json();
+  } catch {
+    return NextResponse.json({
+      success: false,
+      error: "JSONのパースに失敗しました",
+    });
+  }
+
+  if (!data?.category || !CATEGORIES_BY_TYPE.支出.includes(data.category)) {
+    return NextResponse.json({ success: false, error: "categoryが不正です" });
+  }
+
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    return NextResponse.json({
+      success: false,
+      error: "DATABASE_URLが設定されていません",
+    });
+  }
+  const sql = neon(connectionString);
+  const category = data.category;
+
+  try {
+    // 元々予算が未設定(0件)でも、結果的に「未設定」であることに変わりないのでエラーにはしない
+    await sql`DELETE FROM budget WHERE category = ${category}`;
+    return NextResponse.json({ success: true });
+  } catch (e: unknown) {
+    return NextResponse.json({ success: false, error: String(e) });
+  }
+}

--- a/project/src/app/api/budget-search/route.ts
+++ b/project/src/app/api/budget-search/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { neon } from "@neondatabase/serverless";
+
+// Edge Runtimeで動かす理由は src/app/api/insert/route.ts のコメント・CLAUDE.md参照
+export const runtime = "edge";
+
+/**
+ * 設定済みの予算を全件取得するAPIエンドポイント
+ * GET /api/budget-search
+ * (/list画面・/budget画面の初期表示で呼ばれる)
+ */
+export async function GET() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    return NextResponse.json({
+      success: false,
+      error: "DATABASE_URLが設定されていません",
+    });
+  }
+  const sql = neon(connectionString);
+  try {
+    const budgets = await sql`SELECT category, amount FROM budget ORDER BY category`;
+    return NextResponse.json({ success: true, budgets });
+  } catch (e: unknown) {
+    return NextResponse.json({ success: false, error: String(e) });
+  }
+}

--- a/project/src/app/api/budget-upsert/route.ts
+++ b/project/src/app/api/budget-upsert/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { neon } from "@neondatabase/serverless";
+import { validateBudget } from "@/lib/validate";
+
+// Edge Runtimeで動かす理由は src/app/api/insert/route.ts のコメント・CLAUDE.md参照
+export const runtime = "edge";
+
+/**
+ * カテゴリごとの予算を作成/更新するAPIエンドポイント
+ * PUT /api/budget-upsert
+ * (/budget画面の保存ボタンから呼ばれる)
+ */
+export async function PUT(request: Request) {
+  let data;
+  try {
+    data = await request.json();
+  } catch {
+    return NextResponse.json({
+      success: false,
+      error: "JSONのパースに失敗しました",
+    });
+  }
+
+  const validationError = validateBudget(data);
+  if (validationError) {
+    return NextResponse.json({ success: false, error: validationError });
+  }
+
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    return NextResponse.json({
+      success: false,
+      error: "DATABASE_URLが設定されていません",
+    });
+  }
+  const sql = neon(connectionString);
+
+  const category = data.category;
+  const amount = Number.parseInt(data.amount);
+
+  try {
+    // 既に予算があれば上書き、なければ新規作成する
+    await sql`
+      INSERT INTO budget (category, amount)
+      VALUES (${category}, ${amount})
+      ON CONFLICT (category) DO UPDATE SET amount = ${amount}
+    `;
+    return NextResponse.json({ success: true });
+  } catch (e: unknown) {
+    return NextResponse.json({ success: false, error: String(e) });
+  }
+}

--- a/project/src/app/budget/page.tsx
+++ b/project/src/app/budget/page.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+// 予算設定画面(/budget)。支出カテゴリごとに継続的な月間予算額を設定する。
+// カテゴリごとに入力欄と保存ボタンを持ち、行ごとに/api/budget-upsert(金額あり)
+// または/api/budget-delete(空にして保存=未設定に戻す)を呼ぶ
+
+const styles = {
+  card: "max-w-md mx-auto bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl shadow-sm p-6 space-y-4",
+  title: "text-xl font-bold text-center mb-2",
+  description: "text-sm text-slate-500 dark:text-slate-400 text-center mb-4",
+  row: "flex items-center gap-2",
+  category: "w-20 shrink-0 text-sm text-slate-600 dark:text-slate-300",
+  input:
+    "flex-1 rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-950 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:focus:ring-indigo-600",
+  button:
+    "px-3 py-1 text-xs rounded-md font-medium bg-indigo-600 hover:bg-indigo-700 text-white transition-colors cursor-pointer",
+  error:
+    "text-center text-sm rounded-md bg-rose-50 dark:bg-rose-950 text-rose-700 dark:text-rose-300 py-2",
+  loading: "text-center text-slate-500 dark:text-slate-400 py-8",
+};
+
+import React, { useEffect, useState } from "react";
+import { CATEGORIES_BY_TYPE } from "@/lib/categories";
+
+const EXPENSE_CATEGORIES = CATEGORIES_BY_TYPE.支出;
+
+export default function BudgetSettings() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  // カテゴリ -> 入力欄の文字列(未設定なら空文字)
+  const [amounts, setAmounts] = useState<Record<string, string>>({});
+  // カテゴリごとの保存結果メッセージ
+  const [messages, setMessages] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    const fetchBudgets = async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const res = await fetch("/api/budget-search");
+        const data = await res.json();
+        if (data.success) {
+          const next: Record<string, string> = {};
+          for (const b of data.budgets as { category: string; amount: number }[]) {
+            next[b.category] = String(b.amount);
+          }
+          setAmounts(next);
+        } else {
+          setError(data.error || "データ取得に失敗しました");
+        }
+      } catch {
+        setError("通信エラー");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchBudgets();
+  }, []);
+
+  const handleChange = (category: string, value: string) => {
+    setAmounts({ ...amounts, [category]: value });
+  };
+
+  // 保存: 金額が入力されていればupsert、空ならdelete(未設定に戻す)
+  const save = async (category: string) => {
+    setMessages({ ...messages, [category]: "" });
+    const value = amounts[category] ?? "";
+
+    const res =
+      value === ""
+        ? await fetch("/api/budget-delete", {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ category }),
+          })
+        : await fetch("/api/budget-upsert", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ category, amount: value }),
+          });
+
+    const data = await res.json();
+    setMessages({
+      ...messages,
+      [category]: data.success ? "保存しました" : data.error ?? "保存に失敗しました",
+    });
+  };
+
+  return (
+    <div className={styles.card}>
+      <h1 className={styles.title}>予算設定</h1>
+      <p className={styles.description}>
+        カテゴリごとに毎月の予算額を設定できます。空欄で保存すると未設定に戻ります。
+      </p>
+      {error && <div className={styles.error}>{error}</div>}
+      {loading ? (
+        <div className={styles.loading}>読み込み中...</div>
+      ) : (
+        EXPENSE_CATEGORIES.map((category) => (
+          <div key={category} className="space-y-1">
+            <div className={styles.row}>
+              <span className={styles.category}>{category}</span>
+              <input
+                inputMode="numeric"
+                placeholder="未設定"
+                value={amounts[category] ?? ""}
+                onChange={(e) => handleChange(category, e.target.value)}
+                className={styles.input}
+              />
+              <button
+                type="button"
+                className={styles.button}
+                onClick={() => save(category)}
+              >
+                保存
+              </button>
+            </div>
+            {messages[category] && (
+              <div className="text-xs text-slate-500 dark:text-slate-400">
+                {messages[category]}
+              </div>
+            )}
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/project/src/app/layout.tsx
+++ b/project/src/app/layout.tsx
@@ -50,6 +50,12 @@ export default function RootLayout({
               >
                 一覧
               </Link>
+              <Link
+                href="/budget"
+                className="text-slate-600 dark:text-slate-300 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"
+              >
+                予算
+              </Link>
             </nav>
           </div>
         </header>

--- a/project/src/app/list/page.tsx
+++ b/project/src/app/list/page.tsx
@@ -59,6 +59,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { CATEGORIES_BY_TYPE, ITEM_TYPES, ItemType } from "@/lib/categories";
 import { CategoryBarChart } from "@/components/CategoryBarChart";
 import { MonthlyTrendChart } from "@/components/MonthlyTrendChart";
+import { BudgetProgress } from "@/components/BudgetProgress";
 
 // APIから取得の型定義
 type Item = {
@@ -107,6 +108,9 @@ export default function EntryList() {
   // 保存・削除時のエラーメッセージ
   const [actionError, setActionError] = useState("");
 
+  // カテゴリ -> 予算額(/budget画面で設定されたもの。未設定のカテゴリは含まれない)
+  const [budgets, setBudgets] = useState<Record<string, number>>({});
+
   useEffect(() => {
     // 関数の実行タイミングをReactのレンダリング後まで遅らせる
     // 非同期関数
@@ -133,6 +137,27 @@ export default function EntryList() {
       }
     };
     fetchData(); // データ取得実行
+  }, []);
+
+  useEffect(() => {
+    // 予算取得の失敗は一覧表示自体をブロックしない(予算進捗が出ないだけにする)ため、
+    // items取得とは別のuseEffectにしてエラーを分離している
+    const fetchBudgets = async () => {
+      try {
+        const res = await fetch("/api/budget-search");
+        const data = await res.json();
+        if (data.success) {
+          const map: Record<string, number> = {};
+          for (const b of data.budgets as { category: string; amount: number }[]) {
+            map[b.category] = b.amount;
+          }
+          setBudgets(map);
+        }
+      } catch {
+        // 何もしない(予算未取得のまま進捗非表示になるだけ)
+      }
+    };
+    fetchBudgets();
   }, []);
 
   // 一覧に登場する月の一覧(新しい順)。データがない当月分も選べるよう別途追加する
@@ -275,6 +300,24 @@ export default function EntryList() {
     return Array.from(totals, ([category, total]) => ({ category, total }));
   };
 
+  // 予算消化状況(予算は「1ヶ月あたり」の概念なので、月を1つに絞り込んでいるときだけ計算する)
+  const budgetStatuses = useMemo(() => {
+    if (selectedMonth === "all") return [];
+    const spentByCategory = new Map<string, number>();
+    for (const item of filteredItems) {
+      if (item.type !== "支出") continue;
+      spentByCategory.set(
+        item.category,
+        (spentByCategory.get(item.category) ?? 0) + item.price
+      );
+    }
+    return Object.entries(budgets).map(([category, budget]) => ({
+      category,
+      budget,
+      spent: spentByCategory.get(category) ?? 0,
+    }));
+  }, [budgets, filteredItems, selectedMonth]);
+
   // 画面描画
   return (
     <div>
@@ -355,6 +398,12 @@ export default function EntryList() {
               </div>
             </div>
           </div>
+
+          {budgetStatuses.length > 0 && (
+            <div className={styles.trendCard}>
+              <BudgetProgress data={budgetStatuses} />
+            </div>
+          )}
 
           {(totalExpense > 0 || totalIncome > 0) && (
             <div className={styles.chartCard}>

--- a/project/src/components/BudgetProgress.tsx
+++ b/project/src/components/BudgetProgress.tsx
@@ -1,0 +1,49 @@
+// カテゴリごとの予算消化状況を表示するコンポーネント。
+// 「単一の割合を上限と比べる」表現なので、dataviz skillの方針に従いMeter(トラック+塗り)にする。
+// 未塗り部分(トラック)は塗り部分と同系色の薄い色にし、状態が一つのバーとして読めるようにする。
+
+export type BudgetStatus = { category: string; spent: number; budget: number };
+
+const styles = {
+  container: "space-y-3",
+  title: "text-sm font-semibold text-slate-600 dark:text-slate-300 mb-2",
+  row: "space-y-1",
+  labelRow: "flex justify-between items-baseline text-xs",
+  category: "text-slate-600 dark:text-slate-300",
+  amount: "tabular-nums text-slate-600 dark:text-slate-300",
+  amountOver: "tabular-nums text-rose-600 dark:text-rose-400 font-semibold",
+  track: "h-3 rounded bg-rose-100 dark:bg-rose-950 overflow-hidden",
+  fill: "h-full rounded-r bg-rose-500",
+};
+
+export function BudgetProgress({ data }: { data: BudgetStatus[] }) {
+  if (data.length === 0) return null;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.title}>今月の予算消化状況</div>
+      {data.map((d) => {
+        const isOver = d.spent > d.budget;
+        const ratio = d.budget === 0 ? 1 : d.spent / d.budget;
+        const widthPercent = Math.min(ratio, 1) * 100;
+        return (
+          <div key={d.category} className={styles.row}>
+            <div className={styles.labelRow}>
+              <span className={styles.category}>{d.category}</span>
+              <span className={isOver ? styles.amountOver : styles.amount}>
+                {d.spent.toLocaleString()} / {d.budget.toLocaleString()}円
+                {isOver && "(予算超過)"}
+              </span>
+            </div>
+            <div className={styles.track}>
+              <div
+                className={styles.fill}
+                style={{ width: `${widthPercent}%` }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/project/src/lib/validate.test.ts
+++ b/project/src/lib/validate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { validateId, validateItemFields } from "./validate";
+import { validateBudget, validateId, validateItemFields } from "./validate";
 
 describe("validateItemFields", () => {
   const valid = {
@@ -68,5 +68,32 @@ describe("validateId", () => {
 
   it("idが数値でない場合はエラーを返す", () => {
     expect(validateId({ id: "abc" })).not.toBeNull();
+  });
+});
+
+describe("validateBudget", () => {
+  it("支出カテゴリと0以上の金額ではnullを返す", () => {
+    expect(validateBudget({ category: "食費", amount: 40000 })).toBeNull();
+    expect(validateBudget({ category: "食費", amount: 0 })).toBeNull();
+    expect(validateBudget({ category: "食費", amount: "0" })).toBeNull();
+  });
+
+  it("収入カテゴリを指定した場合はエラーを返す", () => {
+    // "給与"は収入用のカテゴリであり、予算の対象は支出カテゴリのみ
+    expect(validateBudget({ category: "給与", amount: 1000 })).not.toBeNull();
+  });
+
+  it("存在しないカテゴリの場合はエラーを返す", () => {
+    expect(validateBudget({ category: "謎", amount: 1000 })).not.toBeNull();
+  });
+
+  it.each([
+    ["空文字", ""],
+    ["undefined", undefined],
+    ["null", null],
+    ["数値でない文字列", "abc"],
+    ["負の値", -1],
+  ])("amountが%s(%s)の場合はエラーを返す", (_label, amount) => {
+    expect(validateBudget({ category: "食費", amount })).not.toBeNull();
   });
 });

--- a/project/src/lib/validate.ts
+++ b/project/src/lib/validate.ts
@@ -30,3 +30,20 @@ export function validateId(data: Record<string, unknown> | null | undefined): st
   if (!data?.id || isNaN(Number(data.id))) return "idが不正です";
   return null;
 }
+
+/**
+ * 予算(category/amount)の入力チェック(budget-upsert/budget-delete共通)。
+ * 問題があればエラーメッセージ(文字列)を、問題なければnullを返す
+ */
+export function validateBudget(
+  data: Record<string, unknown> | null | undefined
+): string | null {
+  if (!data) return "データがありません";
+  if (!CATEGORIES_BY_TYPE.支出.includes(data.category as string))
+    return "categoryが不正です";
+  // 金額0円を許容するため、未入力かどうかとNaN・負の値かどうかを別にチェックする
+  if (data.amount === "" || data.amount == null || isNaN(Number(data.amount)))
+    return "amountが不正です";
+  if (Number(data.amount) < 0) return "amountが不正です";
+  return null;
+}


### PR DESCRIPTION
## Summary
- `budget`テーブル(category, amount)を追加。カテゴリごとに継続的な月間予算額を保持する(マイグレーション作成のみ、**本番未適用**。マージ後に別途確認のうえ適用予定)
- `/api/budget-search`(GET)・`/api/budget-upsert`(PUT)・`/api/budget-delete`(DELETE)を、既存4ルートと同じ規約(Edge Runtime, `neon()`, `{success,...}`形式)で追加
- `src/lib/validate.ts`に`validateBudget`を追加、ユニットテストも追加
- `/budget`ページ(新規)で支出カテゴリごとに予算額を設定
- `/list`画面に`BudgetProgress`(カテゴリごとの予算消化メーター)を追加。月を1つに絞り込んでいるときだけ表示する(予算は月単位の概念のため、「すべての期間」では意味をなさない)
- ヘッダーナビゲーションに「予算」リンクを追加

実装計画は事前にPlan Modeで作成し、承認を得てから実装しています。

Closes #40

## Test plan
- [x] `tsc --noEmit`・`yarn lint`・`yarn test`(26件、budgetのバリデーション8件を含む)がすべてパスすることを確認
- [x] ローカルPostgres + Prisma Clientで、upsert(insert/update)・deleteのSQLロジックが期待通り動作することを確認
- [x] モックデータで`BudgetProgress`を一時的にプレビューし、消化率の計算(80%/100%頭打ち)・予算超過時の警告表示を確認
- [ ] 本番Neon DBへのマイグレーション適用は別途確認のうえ実施
- [ ] 実データでのブラウザ確認は`neon()`のローカル制約により未実施