### PR TITLE
budgetページのstate更新を関数形式に変更

### DIFF
--- a/project/src/app/budget/page.tsx
+++ b/project/src/app/budget/page.tsx
@@ -58,12 +58,14 @@ export default function BudgetSettings() {
   }, []);
 
   const handleChange = (category: string, value: string) => {
-    setAmounts({ ...amounts, [category]: value });
+    // 直前のstateを関数で受け取って更新する(状態更新のたびに再定義されるamountsを
+    // 参照するとクロージャが古い値を指すことがあるため、常に最新のprevから作る)
+    setAmounts((prev) => ({ ...prev, [category]: value }));
   };
 
   // 保存: 金額が入力されていればupsert、空ならdelete(未設定に戻す)
   const save = async (category: string) => {
-    setMessages({ ...messages, [category]: "" });
+    setMessages((prev) => ({ ...prev, [category]: "" }));
     const value = amounts[category] ?? "";
 
     const res =
@@ -80,10 +82,12 @@ export default function BudgetSettings() {
           });
 
     const data = await res.json();
-    setMessages({
-      ...messages,
+    // await をまたぐのでmessagesのクロージャは特に古くなりやすい。関数形式の更新で
+    // 他カテゴリを同時に保存した場合の上書き事故を防ぐ
+    setMessages((prev) => ({
+      ...prev,
       [category]: data.success ? "保存しました" : data.error ?? "保存に失敗しました",
-    });
+    }));
   };
 
   return (


### PR DESCRIPTION
## Summary
- `/budget`画面の`setAmounts`/`setMessages`を、クロージャのstateを直接参照する形から関数形式の更新(`setXxx(prev => ...)`)に変更
- カテゴリごとに独立した非同期の保存処理(`save`)が並行して走りうる箇所で、古いクロージャの値により他カテゴリの更新を上書きしてしまう事故を防ぐ
- `entry`/`list`画面のフォーム状態更新も確認したが、1つのフォームを順番に入力する単純な構造で非同期の隙間がないため、同種のリスクはないと判断し変更していない

react-tutor agentに`budget/page.tsx`の`save`関数を解説してもらった際に指摘された点への対応。

Closes #44

## Test plan
- [x] `tsc --noEmit`・`yarn lint`・`yarn test`(26件)がすべてパスすることを確認