### PR TITLE
各機能の設計書を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,17 @@
 - [docs/react-basics.md](./docs/react-basics.md) — このアプリの実際のコードを使って、Reactの基本的な考え方(コンポーネント・state・propsなど)を説明しています
 - [docs/claude-code-basics.md](./docs/claude-code-basics.md) — `CLAUDE.md`やAgents/Skillsなど、Claude Codeがこのリポジトリを扱うための仕組みを説明しています
 - [docs/development-flow.md](./docs/development-flow.md) — 各ドキュメントの役割と、Issue作成からPRマージまでの開発の流れをまとめています
+- [docs/design/](./docs/design/) — 各機能の設計書(画面構成・データ設計・API仕様・処理フロー)
 
 ## 機能
 
 - 収支の入力(日付・内容・金額・収支種別・カテゴリ)
 - 一覧表示(行クリックでその場編集、削除)
 - 月別の絞り込み・内容検索・並び替え
-- 収入・支出・差引の合計サマリー、カテゴリ別集計グラフ
+- 収入・支出・差引の合計サマリー、カテゴリ別集計グラフ、月次推移グラフ
+- カテゴリごとの予算設定・消化状況の表示
+
+各機能の詳細は [docs/design/](./docs/design/) を参照してください。
 
 ## フォルダ構成
 

--- a/docs/design/budget.md
+++ b/docs/design/budget.md
@@ -1,0 +1,63 @@
+# 設計書: 予算設定(/budget)
+
+全体像・DB設計・共通仕様は [overview.md](./overview.md) を参照。
+
+## 概要
+
+支出カテゴリごとに、継続的な(月替わりしない)月間予算額を設定する画面。ここで設定した値は[list.md](./list.md)の予算消化状況(`BudgetProgress`)で参照される。
+
+対象は支出カテゴリのみ(収入に予算は設定しない)。予算は任意設定で、12個あるカテゴリすべてに強制しない。
+
+関連ファイル: [project/src/app/budget/page.tsx](../../project/src/app/budget/page.tsx)、[project/src/app/api/budget-search/route.ts](../../project/src/app/api/budget-search/route.ts)、[project/src/app/api/budget-upsert/route.ts](../../project/src/app/api/budget-upsert/route.ts)、[project/src/app/api/budget-delete/route.ts](../../project/src/app/api/budget-delete/route.ts)
+
+## 画面構成
+
+支出カテゴリ(`CATEGORIES_BY_TYPE.支出`、12個)を1行ずつ並べたカード。各行は「カテゴリ名 + 金額入力欄(未設定なら空欄) + 保存ボタン」。保存すると、そのカテゴリの行の下にだけ結果メッセージ(「保存しました」など)を表示する。
+
+行ごとに独立して保存できる(フォーム全体の一括送信ではない)。
+
+## 状態管理
+
+| state | 型 | 役割 |
+|---|---|---|
+| `loading` | `boolean` | 初回取得中の表示切り替え |
+| `error` | `string` | 初回取得全体の失敗メッセージ |
+| `amounts` | `Record<category, string>` | カテゴリごとの入力欄の文字列(未設定なら空文字) |
+| `messages` | `Record<category, string>` | カテゴリごとの保存結果メッセージ |
+
+`amounts`/`messages`は12カテゴリ分をまとめて1つのオブジェクトで持ち、更新はいずれも関数形式(`setAmounts(prev => ({ ...prev, [category]: value }))`)。カテゴリごとに独立した非同期の保存が並行して走りうるため、直前のクロージャ値ではなく常に最新の状態から更新する([Issue #44](https://github.com/mHayashi-1001/kakeibo/issues/44)で修正)。
+
+## 処理フロー: 保存(`save`)
+
+金額欄が空文字かどうかで、呼び出すAPIが分岐する。
+
+```mermaid
+flowchart TD
+    A["保存ボタンクリック: save(category)"] --> B["messagesをクリア"]
+    B --> C{"amounts[category] は空文字?"}
+    C -- "はい(未設定に戻す)" --> D["DELETE /api/budget-delete<br/>{ category }"]
+    C -- "いいえ(金額を保存)" --> E["PUT /api/budget-upsert<br/>{ category, amount }"]
+    D --> F["結果に応じてmessagesを更新"]
+    E --> F
+```
+
+## API仕様
+
+### `GET /api/budget-search`
+```json
+{ "success": true, "budgets": [{ "category": "食費", "amount": 40000 }] }
+```
+設定済みの予算のみ返る(未設定のカテゴリは含まれない)。
+
+### `PUT /api/budget-upsert`
+リクエスト: `{ "category": "食費", "amount": "40000" }`
+バリデーション(`validateBudget`): `category`が支出カテゴリの候補に含まれること、`amount`が0以上の数値であること。
+DB操作: `INSERT INTO budget (category, amount) VALUES (...) ON CONFLICT (category) DO UPDATE SET amount = ...`(既にあれば上書き、なければ新規作成)
+
+### `DELETE /api/budget-delete`
+リクエスト: `{ "category": "食費" }`
+DB操作: `DELETE FROM budget WHERE category = ...`。対象行が元々0件でも(=既に未設定でも)エラーにはしない(結果的に「未設定」という状態は変わらないため)。
+
+## list画面との連携
+
+[list.md](./list.md)の予算消化状況は、`/list`画面が独自に`GET /api/budget-search`を呼んで取得する(`/budget`画面とは別のfetch)。`/budget`で保存した内容を`/list`側へリアルタイムに伝える仕組みはなく、`/list`を再読み込みすれば最新の予算が反映される。

--- a/docs/design/entry.md
+++ b/docs/design/entry.md
@@ -1,0 +1,80 @@
+# 設計書: 収支入力(/entry)
+
+全体像・DB設計・共通仕様は [overview.md](./overview.md) を参照。
+
+## 概要
+
+収支(支出または収入)を1件登録するフォーム画面。送信すると`item`テーブルに1行追加される。
+
+関連ファイル: [project/src/app/entry/page.tsx](../../project/src/app/entry/page.tsx)、[project/src/app/api/insert/route.ts](../../project/src/app/api/insert/route.ts)
+
+## 画面構成
+
+カード型の1カラムフォーム。上から順に:
+
+1. **収支種別** — 「支出」「収入」のボタン切り替え(選択中は種別に応じた色で強調表示)
+2. **カテゴリ** — セレクトボックス。選択中の収支種別に応じて候補が変わる(`CATEGORIES_BY_TYPE`参照)
+3. **日付** — `<input type="date">`
+4. **内容** — テキスト入力(品目・メモ)
+5. **金額** — 数値入力(`inputMode="numeric"`)
+6. **登録するボタン** — 送信。結果に応じて成功/エラーメッセージを表示
+
+## 入力項目とバリデーション
+
+| 項目 | フォームのstateキー | 必須 | バリデーション(`validateItemFields`) |
+|---|---|---|---|
+| 収支種別 | `type` | ○ | `ITEM_TYPES`(`"支出"`/`"収入"`)のいずれか |
+| カテゴリ | `category` | ○ | 選択中`type`に対応する`CATEGORIES_BY_TYPE`の候補に含まれること |
+| 日付 | `date` | - | 未入力時はサーバー側で現在時刻を補う |
+| 内容 | `name` | ○ | 空文字不可 |
+| 金額 | `price` | ○ | 数値に変換できること(0円は許容、空文字/undefined/nullは不可) |
+
+## 状態管理
+
+- `form`(1つのオブジェクトにフォーム全項目をまとめて保持)、`message`(結果メッセージ)、`success`(メッセージの成否)の3つの`useState`
+- 収支種別を切り替えると、`category`をその種別の先頭候補にリセットする(支出用と収入用でカテゴリの集合が違うため、無効な組み合わせを防ぐ)
+- 送信成功時はフォームを初期状態にクリアする
+
+## 処理フロー
+
+```mermaid
+sequenceDiagram
+    participant User as ユーザー
+    participant UI as /entry (クライアント)
+    participant API as POST /api/insert (Edge Runtime)
+    participant DB as Neon (neon()経由)
+
+    User->>UI: 各項目を入力
+    UI->>UI: setForm(...) で都度state更新(controlled input)
+    User->>UI: 「登録する」をクリック (onSubmit)
+    UI->>UI: e.preventDefault()、price空文字なら"0"に補完
+    UI->>API: fetch POST { date, name, price, type, category }
+    API->>API: JSONパース → validateItemFields
+    alt バリデーションNG
+        API-->>UI: { success: false, error }
+    else OK
+        API->>DB: INSERT INTO item (...) RETURNING id
+        DB-->>API: 新規id
+        API-->>UI: { success: true, id }
+    end
+    UI->>UI: success/errorメッセージを表示。成功時はフォームをクリア
+```
+
+## API仕様: `POST /api/insert`
+
+**リクエスト**
+```json
+{ "date": "2026-07-01", "name": "スーパーで買い物", "price": "3200", "type": "支出", "category": "食費" }
+```
+
+**レスポンス(成功時)**
+```json
+{ "success": true, "id": 42 }
+```
+
+**レスポンス(失敗時、例: カテゴリ不正)**
+```json
+{ "success": false, "error": "categoryが不正です" }
+```
+
+`id`はDB側の`autoincrement`で自動採番されるため、リクエストに含める必要はない(含めても無視される)。

--- a/docs/design/list.md
+++ b/docs/design/list.md
@@ -1,0 +1,74 @@
+# 設計書: 一覧(/list)
+
+全体像・DB設計・共通仕様は [overview.md](./overview.md) を参照。
+
+## 概要
+
+登録済みの収支を一覧表示し、絞り込み・検索・並び替え・その場編集・削除・各種集計グラフを行う、このアプリで最も機能が多い画面。
+
+関連ファイル: [project/src/app/list/page.tsx](../../project/src/app/list/page.tsx)、[project/src/components/CategoryBarChart.tsx](../../project/src/components/CategoryBarChart.tsx)、[project/src/components/MonthlyTrendChart.tsx](../../project/src/components/MonthlyTrendChart.tsx)、[project/src/components/BudgetProgress.tsx](../../project/src/components/BudgetProgress.tsx)
+
+## 画面構成(上から順)
+
+| ブロック | 絞り込みの影響 | 内容 |
+|---|---|---|
+| フィルタバー | — | 月選択・内容検索・並び替えの入力欄 |
+| 月次推移グラフ | **受けない**(常に全期間) | 月ごとの収入/支出の折れ線グラフ |
+| 収支サマリー | 受ける | 収入・支出・差引の合計 |
+| 予算消化状況 | 受ける、かつ月を1つに絞っている時のみ表示 | カテゴリごとの予算メーター |
+| カテゴリ別内訳 | 受ける | 支出/収入それぞれの横棒グラフ |
+| 明細テーブル | 受ける | 行クリックでその場編集、削除ボタン |
+
+月次推移グラフだけ絞り込みの対象外にしているのは、複数月を横断する推移グラフを1ヶ月に絞ってしまうと意味をなさないため。
+
+## データ取得
+
+初回マウント時に2つの`useEffect`が並行して動く。
+
+1. `GET /api/search` → `item`全件を取得し、`items` stateにセット。取得後、`selectedMonth`を当月に設定する(サーバー/クライアントの日付ズレでのhydrationエラーを避けるため、初期値は`"all"`にしておき取得後に切り替える)
+2. `GET /api/budget-search` → 設定済みの`budget`全件を取得し、`{ category: amount }`の`budgets` stateにセット。失敗しても一覧表示自体はブロックしない(予算進捗が出ないだけにする)
+
+## 絞り込み・検索・並び替え
+
+`useMemo`を使い、`items`から段階的に派生させる。
+
+```mermaid
+flowchart LR
+    items["items (全件)"] -->|"selectedMonthで月を絞る<br/>searchTextで内容を絞る"| filteredItems
+    filteredItems -->|"sortKey/sortOrderで並び替え"| sortedItems["sortedItems (表示用)"]
+    filteredItems --> totals["収入/支出/差引の合計"]
+    filteredItems --> categoryTotals["カテゴリ別集計"]
+    filteredItems --> budgetStatuses["予算消化状況<br/>(月を1つに絞っている時のみ)"]
+    items --> monthlyTotals["月次推移<br/>(絞り込みの影響を受けない)"]
+```
+
+- `selectedMonth`: `"all"`または`"YYYY-MM"`。`toMonthKey(item.date) === selectedMonth`で絞る
+- `searchText`: `item.name`に部分一致するかで絞る
+- `sortKey`/`sortOrder`: `date`または`price`を昇順/降順(デフォルトは日付の新しい順)
+
+## その場編集・削除
+
+- 行をクリックすると`editingId`にその行の`id`をセットし、同じ行がテキスト/セレクトの入力欄に切り替わる(`entry`画面と同様のcontrolled input)
+- 収支種別を変更すると、`entry`画面と同じくカテゴリの選択肢をリセットする
+- 「保存」→`PUT /api/update`、「削除」→`DELETE /api/delete`。成功したらローカルの`items` stateも更新し、再取得はしない(楽観的更新)
+- 削除は`window.confirm`で確認を挟む
+
+## 集計ロジック
+
+- **収支サマリー**: `filteredItems`を`type`で振り分けて合計するだけ
+- **カテゴリ別内訳**: `filteredItems`を`category`ごとに`Map`で積み上げ、`CategoryBarChart`に渡す(支出用・収入用で別々に集計)
+- **月次推移**: `items`(絞り込み前)を`YYYY-MM`ごとに`income`/`expense`で積み上げ、`MonthlyTrendChart`に渡す
+- **予算消化状況**: `selectedMonth === "all"`なら計算しない。それ以外は`filteredItems`のうち`type === "支出"`をカテゴリごとに積み上げ、`budgets`(設定済み予算)とカテゴリ名で突き合わせて`{ category, spent, budget }[]`を作り`BudgetProgress`に渡す
+
+## API仕様
+
+### `GET /api/search`
+```json
+{ "success": true, "items": [{ "id": 1, "date": "2026-07-01T00:00:00.000Z", "name": "スーパーで買い物", "price": 3200, "category": "食費", "type": "支出" }] }
+```
+
+### `PUT /api/update`
+リクエスト: `{ "id": 1, "date": "...", "name": "...", "price": "...", "type": "...", "category": "..." }`(バリデーションは`validateId`+`validateItemFields`)。レスポンス: `{ "success": true }`
+
+### `DELETE /api/delete`
+リクエスト: `{ "id": 1 }`。レスポンス: `{ "success": true }`。対象idが存在しなければ`{ "success": false, "error": "対象のデータが見つかりません" }`

--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -1,0 +1,74 @@
+# 設計書: 全体像
+
+各機能の詳細設計は同じフォルダ内の [entry.md](./entry.md)・[list.md](./list.md)・[budget.md](./budget.md) を参照。このファイルには機能をまたいで共通する設計だけをまとめる。
+
+## システム構成
+
+```mermaid
+flowchart LR
+    Browser["ブラウザ<br/>(React クライアントコンポーネント)"]
+    API["Next.js APIルート<br/>src/app/api/**/route.ts<br/>(Edge Runtime)"]
+    Neon["Neon Postgres<br/>(本番DB)"]
+
+    Browser -- "fetch(JSON)" --> API
+    API -- "neon() タグ付きSQL" --> Neon
+```
+
+- 画面(`src/app/*/page.tsx`)はすべてクライアントコンポーネント(`"use client"`)。`fetch`でAPIルートを呼ぶ
+- APIルートは全て`export const runtime = "edge"`を宣言し、`@neondatabase/serverless`の`neon()`で直接SQLを実行する。Prisma Clientは使わない(理由は[../../CLAUDE.md](../../CLAUDE.md)参照)
+- 本番DBとローカル開発用DBは別接続だが、`project/.env`はデフォルトで本番Neon DBを指す(ステージング環境なし)
+
+## データ設計(DB)
+
+### `item`テーブル — 収支の1件のレコード
+
+| カラム | 型 | 説明 |
+|---|---|---|
+| `id` | Int (PK, autoincrement) | 自動採番 |
+| `date` | DateTime | 取引日 |
+| `name` | String | 内容(品目・メモ) |
+| `price` | Int | 金額(円、0以上) |
+| `category` | String | カテゴリ。既定値`"その他"` |
+| `type` | String | `"支出"` または `"収入"`。既定値`"支出"` |
+
+### `budget`テーブル — カテゴリごとの継続的な月間予算
+
+| カラム | 型 | 説明 |
+|---|---|---|
+| `category` | String (PK) | 支出カテゴリ名(`CATEGORIES_BY_TYPE.支出`のいずれか) |
+| `amount` | Int | 月間予算額(円、0以上) |
+
+行が存在しないカテゴリは「予算未設定」を意味する(NULLではなく行の有無で表現する)。月ごとの個別予算は持たない(継続的に同じ金額が毎月適用される)。
+
+スキーマの定義自体は[../../project/prisma/schema.prisma](../../project/prisma/schema.prisma)、マイグレーション履歴は[../../project/prisma/migrations/](../../project/prisma/migrations/)を参照。
+
+## 共通ロジック
+
+- **[../../project/src/lib/categories.ts](../../project/src/lib/categories.ts)** — `ITEM_TYPES`(収支種別)・`CATEGORIES_BY_TYPE`(種別ごとのカテゴリ候補)を定義。フロントエンドの選択肢とAPIのバリデーションの両方がここを参照し、許容値がずれないようにしている
+- **[../../project/src/lib/validate.ts](../../project/src/lib/validate.ts)** — `validateItemFields`(name/price/type/category)・`validateId`・`validateBudget`(category/amount)。いずれも「問題があればエラー文字列、なければ`null`」という同じ形式
+
+## 共通API仕様
+
+すべてのAPIルートは`{ success: boolean, ... }`形式のJSONを返す。
+
+- 成功時: `{ success: true, ... }`(取得系は追加でデータを含む)
+- 失敗時: `{ success: false, error: string }`。**HTTPステータスは常に200**(エラーコードでは表現しない)
+
+| エンドポイント | メソッド | 用途 | 詳細 |
+|---|---|---|---|
+| `/api/search` | GET | item全件取得 | [entry.md](./entry.md) / [list.md](./list.md) |
+| `/api/insert` | POST | item新規作成 | [entry.md](./entry.md) |
+| `/api/update` | PUT | item更新 | [list.md](./list.md) |
+| `/api/delete` | DELETE | item削除 | [list.md](./list.md) |
+| `/api/budget-search` | GET | budget全件取得 | [budget.md](./budget.md) |
+| `/api/budget-upsert` | PUT | budget作成/更新 | [budget.md](./budget.md) |
+| `/api/budget-delete` | DELETE | budget削除(未設定に戻す) | [budget.md](./budget.md) |
+
+## 画面一覧
+
+| パス | 画面 | 設計書 |
+|---|---|---|
+| `/` | トップページ(各画面へのリンク) | — |
+| `/entry` | 収支入力 | [entry.md](./entry.md) |
+| `/list` | 一覧・絞り込み・検索・並び替え・集計・予算進捗 | [list.md](./list.md) |
+| `/budget` | 予算設定 | [budget.md](./budget.md) |


### PR DESCRIPTION
## Summary
`docs/design/`配下に、機能ごとの設計書を追加した。

- `overview.md`: システム構成図、DB設計(item/budgetテーブル)、共通ロジック・API仕様、画面一覧
- `entry.md`: 収支入力機能。画面構成・入力項目とバリデーション・処理フロー(Mermaidシーケンス図)・API仕様
- `list.md`: 一覧・絞り込み・検索・並び替え・カテゴリ別集計・月次推移・予算進捗表示。データの派生関係(Mermaid図)・集計ロジック・API仕様
- `budget.md`: 予算設定機能。保存時の分岐ロジック(Mermaidフローチャート)・API仕様・list画面との連携

README.mdに設計書への導線を追加、機能一覧も現状(月次推移グラフ・予算機能)に合わせて更新。

コード・DB・APIへの変更はなし(ドキュメントのみ)。

Closes #46

## Test plan
- [x] 追加・変更した全リンクが実在するファイル/ディレクトリを指していることを確認