### PR TITLE
設計書にフロントエンド/バックエンドの分離を明記

### DIFF
--- a/docs/design/budget.md
+++ b/docs/design/budget.md
@@ -8,7 +8,9 @@
 
 対象は支出カテゴリのみ(収入に予算は設定しない)。予算は任意設定で、12個あるカテゴリすべてに強制しない。
 
-関連ファイル: [project/src/app/budget/page.tsx](../../project/src/app/budget/page.tsx)、[project/src/app/api/budget-search/route.ts](../../project/src/app/api/budget-search/route.ts)、[project/src/app/api/budget-upsert/route.ts](../../project/src/app/api/budget-upsert/route.ts)、[project/src/app/api/budget-delete/route.ts](../../project/src/app/api/budget-delete/route.ts)
+関連ファイル:
+- フロントエンド: [project/src/app/budget/page.tsx](../../project/src/app/budget/page.tsx)
+- バックエンド: [project/src/app/api/budget-search/route.ts](../../project/src/app/api/budget-search/route.ts)、[project/src/app/api/budget-upsert/route.ts](../../project/src/app/api/budget-upsert/route.ts)、[project/src/app/api/budget-delete/route.ts](../../project/src/app/api/budget-delete/route.ts)
 
 ## 画面構成
 

--- a/docs/design/entry.md
+++ b/docs/design/entry.md
@@ -6,7 +6,9 @@
 
 収支(支出または収入)を1件登録するフォーム画面。送信すると`item`テーブルに1行追加される。
 
-関連ファイル: [project/src/app/entry/page.tsx](../../project/src/app/entry/page.tsx)、[project/src/app/api/insert/route.ts](../../project/src/app/api/insert/route.ts)
+関連ファイル:
+- フロントエンド: [project/src/app/entry/page.tsx](../../project/src/app/entry/page.tsx)
+- バックエンド: [project/src/app/api/insert/route.ts](../../project/src/app/api/insert/route.ts)
 
 ## 画面構成
 

--- a/docs/design/list.md
+++ b/docs/design/list.md
@@ -6,7 +6,9 @@
 
 登録済みの収支を一覧表示し、絞り込み・検索・並び替え・その場編集・削除・各種集計グラフを行う、このアプリで最も機能が多い画面。
 
-関連ファイル: [project/src/app/list/page.tsx](../../project/src/app/list/page.tsx)、[project/src/components/CategoryBarChart.tsx](../../project/src/components/CategoryBarChart.tsx)、[project/src/components/MonthlyTrendChart.tsx](../../project/src/components/MonthlyTrendChart.tsx)、[project/src/components/BudgetProgress.tsx](../../project/src/components/BudgetProgress.tsx)
+関連ファイル:
+- フロントエンド: [project/src/app/list/page.tsx](../../project/src/app/list/page.tsx)、[project/src/components/CategoryBarChart.tsx](../../project/src/components/CategoryBarChart.tsx)、[project/src/components/MonthlyTrendChart.tsx](../../project/src/components/MonthlyTrendChart.tsx)、[project/src/components/BudgetProgress.tsx](../../project/src/components/BudgetProgress.tsx)
+- バックエンド: [project/src/app/api/search/route.ts](../../project/src/app/api/search/route.ts)、[project/src/app/api/update/route.ts](../../project/src/app/api/update/route.ts)、[project/src/app/api/delete/route.ts](../../project/src/app/api/delete/route.ts)、[project/src/app/api/budget-search/route.ts](../../project/src/app/api/budget-search/route.ts)
 
 ## 画面構成(上から順)
 

--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -4,15 +4,27 @@
 
 ## システム構成
 
+デプロイ先(Cloudflare Pages)は1つだが、コードの役割としてはフロントエンドとバックエンドに分離されている。**フロントエンドはDBに直接アクセスせず、必ずバックエンド(APIルート)を`fetch`経由で呼び出す。**
+
 ```mermaid
 flowchart LR
-    Browser["ブラウザ<br/>(React クライアントコンポーネント)"]
-    API["Next.js APIルート<br/>src/app/api/**/route.ts<br/>(Edge Runtime)"]
+    subgraph FE["フロントエンド(ブラウザで実行)"]
+        Browser["React クライアントコンポーネント<br/>src/app/*/page.tsx<br/>src/components/*.tsx"]
+    end
+    subgraph BE["バックエンド(Edge Runtimeで実行)"]
+        API["Next.js APIルート<br/>src/app/api/**/route.ts"]
+    end
     Neon["Neon Postgres<br/>(本番DB)"]
 
     Browser -- "fetch(JSON)" --> API
     API -- "neon() タグ付きSQL" --> Neon
 ```
+
+| 層 | 場所 | 役割 |
+|---|---|---|
+| フロントエンド | `src/app/*/page.tsx`、`src/components/*.tsx` | 画面表示・ユーザー操作の受付。`fetch`でバックエンドのAPIルートを呼ぶだけで、DBには触れない |
+| バックエンド | `src/app/api/**/route.ts` | リクエストのバリデーション、DBの読み書き(`neon()`で直接SQL実行) |
+| 共有ロジック | `src/lib/*.ts` | フロントエンド・バックエンドの**両方**から参照される定義(カテゴリ候補・バリデーション関数)。片方だけ変更して値がずれることを防ぐ |
 
 - 画面(`src/app/*/page.tsx`)はすべてクライアントコンポーネント(`"use client"`)。`fetch`でAPIルートを呼ぶ
 - APIルートは全て`export const runtime = "edge"`を宣言し、`@neondatabase/serverless`の`neon()`で直接SQLを実行する。Prisma Clientは使わない(理由は[../../CLAUDE.md](../../CLAUDE.md)参照)
@@ -47,7 +59,7 @@ flowchart LR
 - **[../../project/src/lib/categories.ts](../../project/src/lib/categories.ts)** — `ITEM_TYPES`(収支種別)・`CATEGORIES_BY_TYPE`(種別ごとのカテゴリ候補)を定義。フロントエンドの選択肢とAPIのバリデーションの両方がここを参照し、許容値がずれないようにしている
 - **[../../project/src/lib/validate.ts](../../project/src/lib/validate.ts)** — `validateItemFields`(name/price/type/category)・`validateId`・`validateBudget`(category/amount)。いずれも「問題があればエラー文字列、なければ`null`」という同じ形式
 
-## 共通API仕様
+## 共通API仕様(バックエンド)
 
 すべてのAPIルートは`{ success: boolean, ... }`形式のJSONを返す。
 
@@ -64,7 +76,7 @@ flowchart LR
 | `/api/budget-upsert` | PUT | budget作成/更新 | [budget.md](./budget.md) |
 | `/api/budget-delete` | DELETE | budget削除(未設定に戻す) | [budget.md](./budget.md) |
 
-## 画面一覧
+## 画面一覧(フロントエンド)
 
 | パス | 画面 | 設計書 |
 |---|---|---|


### PR DESCRIPTION
## Summary
- `overview.md`のシステム構成図をMermaidの`subgraph`で「フロントエンド(ブラウザで実行)」「バックエンド(Edge Runtimeで実行)」に区分けし、層ごとの役割(場所・責務)を表にまとめた
- 「共通API仕様」→「共通API仕様(バックエンド)」、「画面一覧」→「画面一覧(フロントエンド)」と見出しを明確化
- `entry.md`/`list.md`/`budget.md`の「関連ファイル」も、フロントエンド/バックエンドで分けて記載するよう変更

デプロイは1つ(Cloudflare Pages)だが、フロントエンドはDBに直接触れず必ずAPIルート(バックエンド)経由でアクセスする、という構成がドキュメント上でも視覚的にわかるようにした。

コード・DB・APIへの変更はなし(ドキュメントのみ)。

Closes #48

## Test plan
- [x] 追加・変更した全リンクが実在するファイル/ディレクトリを指していることを確認